### PR TITLE
Cleanup derive and simplify usage

### DIFF
--- a/visula/examples/gltf_viewer.rs
+++ b/visula/examples/gltf_viewer.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 
 use visula::{
     io::gltf::{parse_gltf, GltfMesh},
-    MeshPipeline, Pipeline,
+    MeshPipeline, Pipeline, SimulationRenderData,
 };
 
 #[derive(StructOpt)]
@@ -64,8 +64,8 @@ impl visula::Simulation for Simulation {
 
     fn update(&mut self, _application: &visula::Application) {}
 
-    fn render<'a>(&'a mut self, render_pass: &mut wgpu::RenderPass<'a>) {
-        self.mesh.render(render_pass);
+    fn render(&mut self, data: &mut SimulationRenderData) {
+        self.mesh.render(data);
     }
 }
 

--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -1,10 +1,12 @@
 use bytemuck::{Pod, Zeroable};
 use wgpu::BufferUsages;
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use visula::{
-    BindingBuilder, Buffer, BufferBinding, BufferBindingField, Instance, InstanceBinding,
-    InstanceField, InstanceHandle, LineDelegate, Lines, NagaType, VertexAttrFormat,
-    VertexBufferLayoutBuilder,
+    BindingBuilder, Buffer, BufferBinding, BufferBindingField, BufferInner, Instance,
+    InstanceField, InstanceHandle, LineDelegate, Lines, NagaType, SimulationRenderData,
+    VertexAttrFormat, VertexBufferLayoutBuilder,
 };
 use visula_derive::{delegate, Instance};
 
@@ -63,11 +65,8 @@ impl visula::Simulation for Simulation {
         self.line_buffer.update(application, &self.line_data);
     }
 
-    fn render<'a>(&'a mut self, render_pass: &mut wgpu::RenderPass<'a>) {
-        if self.line_buffer.count != 0 {
-            let line_bindings: &[&dyn InstanceBinding] = &[&self.line_buffer];
-            self.lines.render(render_pass, line_bindings);
-        }
+    fn render(&mut self, data: &mut SimulationRenderData) {
+        self.lines.render(data);
     }
 }
 

--- a/visula/src/bindings/binding_builder.rs
+++ b/visula/src/bindings/binding_builder.rs
@@ -1,6 +1,7 @@
-use crate::VertexBufferLayoutBuilder;
+use crate::{BufferInner, VertexBufferLayoutBuilder};
 use naga::Module;
 use naga::{Expression, Handle};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use wgpu::{BindGroup, BindGroupLayout};
@@ -13,11 +14,13 @@ pub struct BufferBinding {
     pub slot: u32,
     pub fields: Vec<BufferBindingField>,
     pub layout: VertexBufferLayoutBuilder,
+    pub inner: Rc<RefCell<BufferInner>>,
 }
 
 pub struct UniformBinding {
     pub expression: Handle<Expression>,
     pub bind_group_layout: Rc<BindGroupLayout>,
+    pub inner: Rc<RefCell<BufferInner>>,
 }
 
 pub type BindingMap = HashMap<u64, BufferBinding>;

--- a/visula/src/io/zdf.rs
+++ b/visula/src/io/zdf.rs
@@ -13,6 +13,7 @@ pub struct ZdfFile {
     pub camera_center: Vector3,
     pub point_cloud: Vec<Sphere>,
     pub mesh_vertex_buf: wgpu::Buffer,
+    pub mesh_index_buf: wgpu::Buffer,
     pub mesh_vertex_count: usize,
 }
 
@@ -132,9 +133,18 @@ pub fn read_zdf(path: &Path, device: &mut wgpu::Device) -> ZdfFile {
         usage: wgpu::BufferUsages::VERTEX,
     });
 
+    let indices: Vec<u32> = (0..vertices.len()).map(|i| i as u32).collect();
+
+    let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Mesh buffer"),
+        contents: bytemuck::cast_slice(&indices),
+        usage: wgpu::BufferUsages::INDEX,
+    });
+
     ZdfFile {
         point_cloud,
         mesh_vertex_buf: vertex_buffer,
+        mesh_index_buf: index_buffer,
         mesh_vertex_count: vertices.len(),
         camera_center,
     }

--- a/visula/src/lib.rs
+++ b/visula/src/lib.rs
@@ -24,6 +24,7 @@ pub mod io;
 pub mod naga_type;
 pub mod pipelines;
 pub mod primitives;
+pub mod render_pass;
 pub mod simulation;
 pub mod vec_to_buffer;
 pub mod vertex_attr;
@@ -39,14 +40,15 @@ pub mod setup_wasm;
 
 pub use application::Application;
 pub use bindings::*;
-pub use buffer::Buffer;
+pub use buffer::*;
 pub use custom_event::CustomEvent;
 pub use drop_event::DropEvent;
 pub use instances::*;
 pub use naga_type::NagaType;
 pub use pipelines::*;
 pub use primitives::*;
-pub use simulation::Simulation;
+pub use render_pass::*;
+pub use simulation::*;
 
 pub type Vector2 = cgmath::Vector2<f32>;
 pub type Vector3 = cgmath::Vector3<f32>;

--- a/visula/src/mesh.wgsl
+++ b/visula/src/mesh.wgsl
@@ -23,7 +23,7 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.position = u_globals.transform * vec4<f32>(position, 1.0);
-    out.color = vec4<f32>(abs(normal), 1.0);
+    out.color = color;
     return out;
 }
 

--- a/visula/src/pipelines/instanced.rs
+++ b/visula/src/pipelines/instanced.rs
@@ -1,4 +1,4 @@
-use crate::pipelines::pipeline::Pipeline;
+use crate::{pipelines::pipeline::Pipeline, DefaultRenderPassDescriptor, SimulationRenderData};
 
 pub struct InstancedPipeline {
     pub render_pipeline: wgpu::RenderPipeline,
@@ -10,7 +10,16 @@ pub struct InstancedPipeline {
 }
 
 impl Pipeline for InstancedPipeline {
-    fn render<'a>(&'a mut self, render_pass: &mut wgpu::RenderPass<'a>) {
+    fn render(&mut self, data: &mut SimulationRenderData) {
+        let SimulationRenderData {
+            encoder,
+            view,
+            depth_texture,
+            ..
+        } = data;
+        let default_render_pass =
+            DefaultRenderPassDescriptor::new("instanced", view, depth_texture);
+        let mut render_pass = encoder.begin_render_pass(&default_render_pass.build());
         render_pass.set_pipeline(&self.render_pipeline);
         render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));

--- a/visula/src/pipelines/lines.rs
+++ b/visula/src/pipelines/lines.rs
@@ -1,7 +1,10 @@
-use crate::{Application, BindingBuilder, InstanceBinding};
+use crate::{
+    Application, BindingBuilder, BufferBinding, DefaultRenderPassDescriptor, SimulationRenderData,
+};
 use bytemuck::{Pod, Zeroable};
 use naga::back::wgsl::WriterFlags;
 use naga::{valid::ValidationFlags, Block, Handle, Statement};
+use std::cell::Ref;
 use std::mem::size_of;
 use visula_derive::define_delegate;
 use wgpu::BufferUsages;
@@ -187,36 +190,74 @@ impl Lines {
         })
     }
 
-    pub fn render<'a>(
-        &'a mut self,
-        render_pass: &mut wgpu::RenderPass<'a>,
-        bindings: &[&'a dyn InstanceBinding<'a>],
+    pub fn render(
+        &self,
+        SimulationRenderData {
+            encoder,
+            view,
+            depth_texture,
+            camera_bind_group,
+            ..
+        }: &mut SimulationRenderData,
     ) {
         log::debug!("Rendering lines");
-        render_pass.set_pipeline(&self.render_pipeline);
-        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-        let mut instance_count = 0;
-        for binding in bindings {
-            if self
-                .binding_builder
-                .bindings
-                .contains_key(&binding.handle())
-            {
-                let slot = self.binding_builder.bindings[&binding.handle()].slot;
-                log::debug!("Setting vertex buffer {}", slot);
-                render_pass.set_vertex_buffer(slot, binding.buffer().slice(..));
-                instance_count = instance_count.max(binding.count());
+        let mut count = None;
+        for binding in self.binding_builder.bindings.values() {
+            let other = binding.inner.borrow().count;
+            if other == 0 {
+                count = None;
+                break;
             }
-            if self
-                .binding_builder
-                .uniforms
-                .contains_key(&binding.handle())
-            {
-                log::debug!("Setting bind group {}", 1);
-                render_pass.set_bind_group(1, binding.bind_group(), &[]);
+            count = match count {
+                None => Some(other),
+                Some(old) => {
+                    if other != old {
+                        None
+                    } else {
+                        Some(old)
+                    }
+                }
             }
         }
-        render_pass.draw_indexed(0..self.index_count as u32, 0, 0..instance_count);
+        log::debug!("Line count {count:#?}");
+        if count == None {
+            log::debug!("Empty line buffer detected. Aborting render of lines.");
+            return;
+        }
+
+        let bindings: Vec<(&BufferBinding, Ref<wgpu::Buffer>)> = self
+            .binding_builder
+            .bindings
+            .values()
+            .map(|v| (v, Ref::map(v.inner.borrow(), |v| &v.buffer)))
+            .collect();
+        let uniforms: Vec<Ref<wgpu::BindGroup>> = self
+            .binding_builder
+            .uniforms
+            .values()
+            .map(|v| Ref::map(v.inner.borrow(), |m| &m.bind_group))
+            .collect();
+        {
+            let default_render_pass =
+                DefaultRenderPassDescriptor::new("lines", view, depth_texture);
+            let mut render_pass = encoder.begin_render_pass(&default_render_pass.build());
+            render_pass.set_bind_group(0, camera_bind_group, &[]);
+
+            render_pass.set_pipeline(&self.render_pipeline);
+            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            let mut instance_count = 0;
+            for (binding, buffer) in bindings.iter() {
+                let slot = binding.slot;
+                log::debug!("Setting vertex buffer {}", slot);
+                render_pass.set_vertex_buffer(slot, buffer.slice(..));
+                instance_count = instance_count.max(binding.inner.borrow().count);
+            }
+            for bind_group in uniforms.iter() {
+                log::debug!("Setting bind group {}", 1);
+                render_pass.set_bind_group(1, bind_group, &[]);
+            }
+            render_pass.draw_indexed(0..self.index_count as u32, 0, 0..instance_count as u32);
+        }
     }
 }

--- a/visula/src/pipelines/mesh.rs
+++ b/visula/src/pipelines/mesh.rs
@@ -4,6 +4,7 @@ use wgpu::util::DeviceExt;
 
 use crate::pipelines::pipeline::Pipeline;
 use crate::primitives::mesh::MeshVertexAttributes;
+use crate::{DefaultRenderPassDescriptor, SimulationRenderData};
 
 pub struct MeshPipeline {
     pub render_pipeline: wgpu::RenderPipeline,
@@ -13,7 +14,18 @@ pub struct MeshPipeline {
 }
 
 impl Pipeline for MeshPipeline {
-    fn render<'a>(&'a mut self, render_pass: &mut wgpu::RenderPass<'a>) {
+    fn render(&mut self, data: &mut SimulationRenderData) {
+        let SimulationRenderData {
+            encoder,
+            view,
+            depth_texture,
+            camera_bind_group,
+            ..
+        } = data;
+        let default_render_pass = DefaultRenderPassDescriptor::new("mesh", view, depth_texture);
+        let mut render_pass = encoder.begin_render_pass(&default_render_pass.build());
+        render_pass.set_bind_group(0, camera_bind_group, &[]);
+
         render_pass.set_pipeline(&self.render_pipeline);
         render_pass.set_vertex_buffer(0, self.vertex_buf.slice(..));
         render_pass.set_index_buffer(self.index_buf.slice(..), wgpu::IndexFormat::Uint32);

--- a/visula/src/pipelines/pipeline.rs
+++ b/visula/src/pipelines/pipeline.rs
@@ -1,3 +1,5 @@
+use crate::SimulationRenderData;
+
 pub trait Pipeline {
-    fn render<'a>(&'a mut self, render_pass: &mut wgpu::RenderPass<'a>);
+    fn render(&mut self, data: &mut SimulationRenderData);
 }

--- a/visula/src/primitives/sphere.rs
+++ b/visula/src/primitives/sphere.rs
@@ -1,5 +1,7 @@
 use crate::{NagaType, VertexAttrFormat};
 use bytemuck::{Pod, Zeroable};
+use std::cell::RefCell;
+use std::rc::Rc;
 use visula_derive::*;
 
 #[repr(C)]

--- a/visula/src/render_pass.rs
+++ b/visula/src/render_pass.rs
@@ -1,0 +1,43 @@
+use wgpu::RenderPassDescriptor;
+
+pub struct DefaultRenderPassDescriptor<'a> {
+    label: String,
+    color_attachments: [wgpu::RenderPassColorAttachment<'a>; 1],
+    depth_texture: &'a wgpu::TextureView,
+}
+
+impl<'b> DefaultRenderPassDescriptor<'b> {
+    pub fn new<'a>(
+        label: &'a str,
+        view: &'a wgpu::TextureView,
+        depth_texture: &'a wgpu::TextureView,
+    ) -> DefaultRenderPassDescriptor<'a> {
+        let color_attachments = [wgpu::RenderPassColorAttachment {
+            view,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Load,
+                store: true,
+            },
+        }];
+        DefaultRenderPassDescriptor {
+            color_attachments,
+            label: label.to_string(),
+            depth_texture,
+        }
+    }
+    pub fn build(&self) -> RenderPassDescriptor {
+        wgpu::RenderPassDescriptor {
+            label: Some(&self.label),
+            color_attachments: &self.color_attachments,
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: self.depth_texture,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: true,
+                }),
+                stencil_ops: None,
+            }),
+        }
+    }
+}

--- a/visula/src/simulation.rs
+++ b/visula/src/simulation.rs
@@ -5,11 +5,26 @@ use winit::event::WindowEvent;
 
 use crate::application::Application;
 
+pub struct SimulationRenderData<'a> {
+    pub view: &'a wgpu::TextureView,
+    pub depth_texture: &'a wgpu::TextureView,
+    pub encoder: &'a mut wgpu::CommandEncoder,
+    pub camera_bind_group: &'a wgpu::BindGroup,
+}
+
 pub trait Simulation: Sized {
     type Error: Debug;
     fn init(application: &mut Application) -> Result<Self, Self::Error>;
     fn handle_event(&mut self, _application: &mut Application, _event: &WindowEvent) {}
     fn update(&mut self, _application: &Application) {}
-    fn render<'a>(&'a mut self, _render_pass: &mut wgpu::RenderPass<'a>) {}
+    fn render(&mut self, _data: &mut SimulationRenderData) {}
     fn gui(&mut self, _context: &Context) {}
+    fn clear_color(&self) -> wgpu::Color {
+        wgpu::Color {
+            r: 0.1,
+            g: 0.2,
+            b: 0.3,
+            a: 1.0,
+        }
+    }
 }


### PR DESCRIPTION
This change keeps reference to buffers around so the user does not need to pass them in during the render stage. Hopefully I will be able to make this API a bit less implicit later, but for now I think using a `Rc<RefCell<BufferInner>>` makes the API way easier to use and is worth the loss of explicitness.