### PR TITLE
Use glam in molecular_dynamics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "glow"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2289,7 @@ dependencies = [
  "env_logger",
  "epi",
  "futures",
+ "glam",
  "gltf",
  "itertools-num",
  "js-sys",

--- a/visula/Cargo.toml
+++ b/visula/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen = "=0.2.78"
 cgmath = "0.17.0"
+glam = {version = "0.20", features = ["bytemuck"]}
 bytemuck = { version = "1.4", features = ["derive"] }
 js-sys = "0.3"
 trajan = "0.1.0"

--- a/visula/src/naga_type.rs
+++ b/visula/src/naga_type.rs
@@ -50,3 +50,22 @@ add_naga_type! {
 add_naga_float_vector! {2, naga::VectorSize::Bi}
 add_naga_float_vector! {3, naga::VectorSize::Tri}
 add_naga_float_vector! {4, naga::VectorSize::Quad}
+
+macro_rules! add_naga_glam_vector {
+    ($glam_type:ty, $vector_size:expr) => {
+        add_naga_type! {
+            $glam_type, naga::Type {
+                name: None,
+                inner: naga::TypeInner::Vector {
+                    kind: naga::ScalarKind::Float,
+                    width: 4,
+                    size: $vector_size,
+                },
+            }
+        }
+    };
+}
+
+add_naga_glam_vector! {glam::Vec2, naga::VectorSize::Bi}
+add_naga_glam_vector! {glam::Vec3, naga::VectorSize::Tri}
+add_naga_glam_vector! {glam::Vec4, naga::VectorSize::Quad}

--- a/visula/src/vertex_attr_format.rs
+++ b/visula/src/vertex_attr_format.rs
@@ -1,3 +1,5 @@
+use glam::{Vec2, Vec3, Vec4};
+
 pub trait VertexAttrFormat {
     fn vertex_attr_format() -> wgpu::VertexFormat;
 }
@@ -21,6 +23,24 @@ impl VertexAttrFormat for [f32; 3] {
 }
 
 impl VertexAttrFormat for [f32; 4] {
+    fn vertex_attr_format() -> wgpu::VertexFormat {
+        wgpu::VertexFormat::Float32x4
+    }
+}
+
+impl VertexAttrFormat for Vec2 {
+    fn vertex_attr_format() -> wgpu::VertexFormat {
+        wgpu::VertexFormat::Float32x2
+    }
+}
+
+impl VertexAttrFormat for Vec3 {
+    fn vertex_attr_format() -> wgpu::VertexFormat {
+        wgpu::VertexFormat::Float32x3
+    }
+}
+
+impl VertexAttrFormat for Vec4 {
     fn vertex_attr_format() -> wgpu::VertexFormat {
         wgpu::VertexFormat::Float32x4
     }


### PR DESCRIPTION
This uses glam instead of arrays and cgmath. This is due to glam
implementing Pod and Zeroable, which allows us to reduce the number of
buffers.