### PR TITLE
Remove delegate macro in favor of operator overloading

### DIFF
--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -2,11 +2,11 @@ use bytemuck::{Pod, Zeroable};
 use wgpu::BufferUsages;
 
 use visula::{
-    BindingBuilder, Buffer, BufferBinding, BufferBindingField, BufferInner, Instance,
-    InstanceField, InstanceHandle, LineDelegate, Lines, NagaType, SimulationRenderData,
-    VertexAttrFormat, VertexBufferLayoutBuilder,
+    BindingBuilder, Buffer, BufferBinding, BufferBindingField, BufferInner, Expression,
+    ExpressionInner, Instance, InstanceField, InstanceHandle, LineDelegate, Lines, NagaType,
+    SimulationRenderData, VertexAttrFormat, VertexBufferLayoutBuilder,
 };
-use visula_derive::{delegate, Instance};
+use visula_derive::Instance;
 
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
@@ -38,10 +38,13 @@ impl visula::Simulation for Simulation {
         let lines = Lines::new(
             application,
             &LineDelegate {
-                start: delegate!(line.position_a),
-                end: delegate!(line.position_b),
-                width: delegate!(1.0),
-                alpha: delegate!(1.0),
+                start: line.position_a,
+                end: line.position_b,
+                width: {
+                    let a: Expression = 1.0.into();
+                    a + 1.0 + 2.0
+                },
+                alpha: 1.0.into(),
             },
         )
         .unwrap();

--- a/visula/examples/neuron.rs
+++ b/visula/examples/neuron.rs
@@ -6,11 +6,11 @@ use wgpu::BufferUsages;
 use glam::Vec3;
 use visula::{
     simulation::SimulationRenderData, BindingBuilder, Buffer, BufferBinding, BufferBindingField,
-    BufferInner, CustomEvent, Instance, InstanceField, InstanceHandle, LineDelegate, Lines,
-    NagaType, SphereDelegate, Spheres, Uniform, UniformBinding, UniformField, UniformHandle,
-    VertexAttrFormat, VertexBufferLayoutBuilder,
+    BufferInner, CustomEvent, Expression, ExpressionInner, Instance, InstanceField, InstanceHandle,
+    LineDelegate, Lines, NagaType, SphereDelegate, Spheres, Uniform, UniformBinding, UniformField,
+    UniformHandle, VertexAttrFormat, VertexBufferLayoutBuilder,
 };
-use visula_derive::{delegate, Instance, Uniform};
+use visula_derive::{Instance, Uniform};
 use winit::{
     dpi::PhysicalPosition,
     event::{ElementState, Event, MouseButton, WindowEvent},
@@ -84,6 +84,12 @@ struct Simulation {
     mouse: Mouse,
 }
 
+macro_rules! delegate_vec {
+    ($($elements:expr),+) => {
+        Expression::new(ExpressionInner::Vector {components: vec![ $($elements.into()),+ ]})
+    }
+}
+
 impl visula::Simulation for Simulation {
     type Error = Error;
     fn init(application: &mut visula::Application) -> Result<Simulation, Error> {
@@ -119,13 +125,13 @@ impl visula::Simulation for Simulation {
         let spheres = Spheres::new(
             application,
             &SphereDelegate {
-                position: delegate!(pos),
-                radius: delegate!(settings.radius),
-                color: delegate!(vec3::<f32>(
-                    0.1 + (particle.voltage + 10.0) / 120.0,
-                    0.2 + (particle.voltage + 10.0) / 120.0,
-                    0.3 + (particle.voltage + 10.0) / 120.0
-                )),
+                position: pos.clone(),
+                radius: settings.radius,
+                color: delegate_vec![
+                    0.1 + (particle.voltage.clone() + 10.0) / 120.0,
+                    0.2 + (particle.voltage.clone() + 10.0) / 120.0,
+                    0.3 + (particle.voltage.clone() + 10.0) / 120.0
+                ],
             },
         )
         .unwrap();
@@ -133,10 +139,10 @@ impl visula::Simulation for Simulation {
         let lines = Lines::new(
             application,
             &LineDelegate {
-                start: delegate!(bond.position_a),
-                end: delegate!(bond.position_b),
-                width: delegate!(settings.width),
-                alpha: delegate!(bond.strength),
+                start: bond.position_a,
+                end: bond.position_b,
+                width: settings.width,
+                alpha: bond.strength,
             },
         )
         .unwrap();

--- a/visula/examples/viewer.rs
+++ b/visula/examples/viewer.rs
@@ -7,11 +7,11 @@ use wgpu::BufferUsages;
 use winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 
 use visula::{
-    BindingBuilder, Buffer, BufferInner, CustomEvent, DropEvent, MeshPipeline, Pipeline,
-    SimulationRenderData, Sphere, SphereDelegate, Spheres, Uniform, UniformBinding, UniformField,
-    UniformHandle,
+    BindingBuilder, Buffer, BufferInner, CustomEvent, DropEvent, Expression, ExpressionInner,
+    MeshPipeline, Pipeline, SimulationRenderData, Sphere, SphereDelegate, Spheres, Uniform,
+    UniformBinding, UniformField, UniformHandle,
 };
-use visula_derive::{delegate, Uniform};
+use visula_derive::Uniform;
 
 #[derive(StructOpt)]
 struct Cli {
@@ -103,9 +103,9 @@ impl visula::Simulation for Simulation {
         let points = Spheres::new(
             application,
             &SphereDelegate {
-                position: delegate!(sphere.position),
-                radius: delegate!(settings.radius),
-                color: delegate!(sphere.color),
+                position: sphere.position,
+                radius: settings.radius,
+                color: sphere.color,
             },
         )
         .unwrap();
@@ -145,7 +145,7 @@ impl visula::Simulation for Simulation {
             } => match window_event {
                 WindowEvent::DroppedFile(path) => {
                     log::info!("Dropped file {:?}", path);
-                    let bytes = std::fs::read(&path).unwrap();
+                    let bytes = std::fs::read(path).unwrap();
                     let drop_event = DropEvent {
                         name: path.to_str().unwrap().to_string(),
                         bytes,

--- a/visula/src/lib.rs
+++ b/visula/src/lib.rs
@@ -29,6 +29,7 @@ pub mod pipelines;
 pub mod primitives;
 pub mod render_pass;
 pub mod simulation;
+pub mod value;
 pub mod vec_to_buffer;
 pub mod vertex_attr;
 pub mod vertex_attr_format;
@@ -52,6 +53,7 @@ pub use pipelines::*;
 pub use primitives::*;
 pub use render_pass::*;
 pub use simulation::*;
+pub use value::*;
 
 pub type Vector2 = cgmath::Vector2<f32>;
 pub type Vector3 = cgmath::Vector3<f32>;

--- a/visula/src/pipelines/lines.rs
+++ b/visula/src/pipelines/lines.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use bytemuck::{Pod, Zeroable};
 use naga::back::wgsl::WriterFlags;
-use naga::{valid::ValidationFlags, Block, Handle, Statement};
+use naga::{valid::ValidationFlags, Block, Statement};
 use std::cell::Ref;
 use std::mem::size_of;
 use visula_derive::define_delegate;
@@ -220,7 +220,7 @@ impl Lines {
             }
         }
         log::debug!("Line count {count:#?}");
-        if count == None {
+        if count.is_none() {
             log::debug!("Empty line buffer detected. Aborting render of lines.");
             return;
         }

--- a/visula/src/pipelines/spheres.rs
+++ b/visula/src/pipelines/spheres.rs
@@ -2,7 +2,7 @@ use crate::simulation::SimulationRenderData;
 use crate::{Application, DefaultRenderPassDescriptor};
 use crate::{BindingBuilder, BufferBinding};
 use bytemuck::{Pod, Zeroable};
-use naga::{back::wgsl::WriterFlags, valid::ValidationFlags, Block, Handle, Statement};
+use naga::{back::wgsl::WriterFlags, valid::ValidationFlags, Block, Statement};
 use std::cell::Ref;
 use std::mem::size_of;
 use visula_derive::define_delegate;
@@ -209,7 +209,7 @@ impl Spheres {
             }
         }
         log::debug!("Line count {count:#?}");
-        if count == None {
+        if count.is_none() {
             log::debug!("Empty spheres buffer detected. Aborting render of spheres.");
             return;
         }

--- a/visula/src/primitives/sphere.rs
+++ b/visula/src/primitives/sphere.rs
@@ -1,3 +1,4 @@
+use crate::Expression;
 use bytemuck::{Pod, Zeroable};
 use visula_derive::*;
 

--- a/visula/src/value.rs
+++ b/visula/src/value.rs
@@ -1,0 +1,351 @@
+use std::{
+    fmt::{Error, Formatter},
+    ops::{Add, Div},
+};
+
+use crate::{BindingBuilder, InstanceField, UniformField};
+
+#[derive(Clone)]
+pub enum ExpressionInner {
+    BinaryOperator {
+        left: Expression,
+        right: Expression,
+        operator: naga::BinaryOperator,
+    },
+    Constant(naga::ConstantInner),
+    InstanceField(InstanceField),
+    UniformField(UniformField),
+    Vector {
+        components: Vec<Expression>,
+    },
+}
+
+pub trait AsValue {
+    fn as_value(&self) -> ExpressionInner;
+}
+
+impl AsValue for InstanceField {
+    fn as_value(&self) -> ExpressionInner {
+        ExpressionInner::InstanceField(self.clone())
+    }
+}
+
+impl AsValue for UniformField {
+    fn as_value(&self) -> ExpressionInner {
+        ExpressionInner::UniformField(self.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct Expression {
+    inner: Box<ExpressionInner>,
+}
+
+impl Expression {
+    pub fn setup(
+        &self,
+        module: &mut naga::Module,
+        binding_builder: &mut BindingBuilder,
+    ) -> naga::Handle<naga::Expression> {
+        let val = self.inner.clone();
+
+        match *val {
+            ExpressionInner::Constant(inner) => {
+                // TODO handle non-float type
+                let constant = module.constants.append(
+                    ::naga::Constant {
+                        name: None,
+                        specialization: None,
+                        inner,
+                    },
+                    ::naga::Span::default(),
+                );
+                module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        ::naga::Expression::Constant(constant),
+                        ::naga::Span::default(),
+                    )
+            }
+            ExpressionInner::Vector { components } => {
+                let naga_type = ::naga::Type {
+                    name: None,
+                    inner: ::naga::TypeInner::Vector {
+                        kind: ::naga::ScalarKind::Float,
+                        width: 4,
+                        size: ::naga::VectorSize::Tri,
+                    },
+                };
+                let field_type = module.types.insert(naga_type, ::naga::Span::default());
+                let components_setup = components
+                    .iter()
+                    .map(|component| component.setup(module, binding_builder))
+                    .collect();
+                module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        ::naga::Expression::Compose {
+                            ty: field_type,
+                            components: components_setup,
+                        },
+                        ::naga::Span::default(),
+                    )
+            }
+            ExpressionInner::BinaryOperator {
+                left,
+                right,
+                operator,
+            } => {
+                let left_setup = left.setup(module, binding_builder);
+                let right_setup = right.setup(module, binding_builder);
+                module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        naga::Expression::Binary {
+                            op: operator,
+                            left: left_setup,
+                            right: right_setup,
+                        },
+                        naga::Span::default(),
+                    )
+            }
+            ExpressionInner::InstanceField(field) => {
+                if !binding_builder.bindings.contains_key(&field.buffer_handle) {
+                    (field.integrate_buffer)(
+                        &field.inner,
+                        field.buffer_handle,
+                        module,
+                        binding_builder,
+                    );
+                }
+                module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        naga::Expression::FunctionArgument(
+                            binding_builder.bindings[&field.buffer_handle].fields
+                                [field.field_index]
+                                .function_argument,
+                        ),
+                        naga::Span::default(),
+                    )
+            }
+            ExpressionInner::UniformField(field) => {
+                let inner = field.inner.borrow();
+                if !binding_builder.bindings.contains_key(&field.buffer_handle) {
+                    (field.integrate_buffer)(
+                        &field.inner,
+                        field.buffer_handle,
+                        module,
+                        binding_builder,
+                        &inner.bind_group_layout,
+                    );
+                }
+                let access_index = module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        naga::Expression::AccessIndex {
+                            index: field.field_index as u32,
+                            base: binding_builder.uniforms[&field.buffer_handle].expression,
+                        },
+                        naga::Span::default(),
+                    );
+                module.entry_points[binding_builder.entry_point_index]
+                    .function
+                    .expressions
+                    .append(
+                        naga::Expression::Load {
+                            pointer: access_index,
+                        },
+                        naga::Span::default(),
+                    )
+            }
+        }
+    }
+
+    pub fn new(value: ExpressionInner) -> Expression {
+        Expression {
+            inner: Box::new(value),
+        }
+    }
+}
+
+impl std::fmt::Debug for Expression {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let value = self.inner.clone();
+        match *value {
+            ExpressionInner::BinaryOperator { left, right, .. } => {
+                write!(fmt, "BinaryOperator {{ left:")?;
+                left.fmt(fmt)?;
+                write!(fmt, "right: ")?;
+                right.fmt(fmt)?;
+                write!(fmt, "}}")?;
+            }
+            ExpressionInner::Constant { .. } => {
+                write!(fmt, "Constant")?;
+            }
+            ExpressionInner::InstanceField(_) => {
+                write!(fmt, "InstanceField")?;
+            }
+            ExpressionInner::UniformField(_) => {
+                write!(fmt, "UniformField")?;
+            }
+            ExpressionInner::Vector { .. } => {
+                write!(fmt, "Vector")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Add for &Expression {
+    type Output = Expression;
+
+    fn add(self, other: &Expression) -> Expression {
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self.clone(),
+            right: other.clone(),
+            operator: naga::BinaryOperator::Add,
+        })
+    }
+}
+
+impl Add for Expression {
+    type Output = Expression;
+
+    fn add(self, other: Expression) -> Expression {
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self,
+            right: other,
+            operator: naga::BinaryOperator::Add,
+        })
+    }
+}
+
+impl Add<f32> for Expression {
+    type Output = Expression;
+
+    fn add(self, other: f32) -> Expression {
+        let other_scalar: Expression = other.into();
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self,
+            right: other_scalar,
+            operator: naga::BinaryOperator::Add,
+        })
+    }
+}
+
+impl Add<f32> for &Expression {
+    type Output = Expression;
+
+    fn add(self, other: f32) -> Expression {
+        self.clone() + other
+    }
+}
+
+impl Add<Expression> for f32 {
+    type Output = Expression;
+
+    fn add(self, other: Expression) -> Expression {
+        other + self
+    }
+}
+
+impl Add<&Expression> for f32 {
+    type Output = Expression;
+
+    fn add(self, other: &Expression) -> Expression {
+        other + self
+    }
+}
+
+impl Add<&Expression> for Expression {
+    type Output = Expression;
+
+    fn add(self, other: &Expression) -> Expression {
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self,
+            right: other.clone(),
+            operator: naga::BinaryOperator::Add,
+        })
+    }
+}
+
+impl Div<f32> for Expression {
+    type Output = Expression;
+
+    fn div(self, other: f32) -> Expression {
+        let other_scalar: Expression = other.into();
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self,
+            right: other_scalar,
+            operator: naga::BinaryOperator::Divide,
+        })
+    }
+}
+
+impl Div<f32> for &Expression {
+    type Output = Expression;
+
+    fn div(self, other: f32) -> Expression {
+        self.clone() / other
+    }
+}
+
+impl Add<i32> for Expression {
+    type Output = Expression;
+
+    fn add(self, other: i32) -> Expression {
+        let other_scalar: Expression = other.into();
+        Expression::new(ExpressionInner::BinaryOperator {
+            left: self,
+            right: other_scalar,
+            operator: naga::BinaryOperator::Add,
+        })
+    }
+}
+
+impl Add<i32> for &Expression {
+    type Output = Expression;
+
+    fn add(self, other: i32) -> Expression {
+        self.clone() + other
+    }
+}
+
+impl Add<Expression> for i32 {
+    type Output = Expression;
+
+    fn add(self, other: Expression) -> Expression {
+        other + self
+    }
+}
+
+impl Add<&Expression> for i32 {
+    type Output = Expression;
+
+    fn add(self, other: &Expression) -> Expression {
+        other + self
+    }
+}
+impl From<f32> for Expression {
+    fn from(value: f32) -> Expression {
+        Expression::new(ExpressionInner::Constant(naga::ConstantInner::Scalar {
+            value: naga::ScalarValue::Float(value as f64),
+            width: 4,
+        }))
+    }
+}
+
+impl From<i32> for Expression {
+    fn from(value: i32) -> Expression {
+        Expression::new(ExpressionInner::Constant(naga::ConstantInner::Scalar {
+            value: naga::ScalarValue::Sint(value as i64),
+            width: 4,
+        }))
+    }
+}


### PR DESCRIPTION
This change introduces value types that are chained with operator overloading to provide the necessary features. This removes the need for the delegate! macro. Some features, such as vectors, are still a bit cumbersome to implement. Further, this does not yet provide compile-time type-checking. This might be introduced in a later change.