### PR TITLE
Introduce instance buffer in Python

### DIFF
--- a/visula/examples/molecular_dynamics.rs
+++ b/visula/examples/molecular_dynamics.rs
@@ -235,7 +235,7 @@ impl Simulation {
                 _padding: Default::default(),
             })
             .collect_vec();
-        let mut color_buffer = application.device.create_instance_buffer::<ColorData>();
+        let color_buffer = application.device.create_instance_buffer::<ColorData>();
         let color = color_buffer.instance();
         color_buffer.update(&application.device, &application.queue, &color_data);
         let spheres = Spheres::new(

--- a/visula/examples/neuronify.rs
+++ b/visula/examples/neuronify.rs
@@ -291,7 +291,7 @@ impl Simulation {
         )
         .unwrap();
 
-        let mut boundary_buffer = InstanceBuffer::<LineData>::new(&application.device);
+        let boundary_buffer = InstanceBuffer::<LineData>::new(&application.device);
         let boundary = boundary_buffer.instance();
         let boundaries = Lines::new(
             &application.rendering_descriptor(),

--- a/visula/examples/wgpu.rs
+++ b/visula/examples/wgpu.rs
@@ -132,7 +132,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     let line = line_buffer.instance();
 
     let mut camera_controller = CameraController::new(&window);
-    let mut camera = Camera::new(&device);
+    let camera = Camera::new(&device);
 
     let lines = Lines::new(
         &RenderingDescriptor {

--- a/visula/src/application.rs
+++ b/visula/src/application.rs
@@ -190,7 +190,7 @@ impl Application {
         self.camera.update(&camera_uniforms, &self.queue);
     }
 
-    pub fn next_frame(&mut self) -> SurfaceTexture {
+    pub fn next_frame(&self) -> SurfaceTexture {
         match self.surface.get_current_texture() {
             Ok(frame) => frame,
             Err(_) => {
@@ -202,13 +202,13 @@ impl Application {
         }
     }
 
-    pub fn encoder(&mut self) -> CommandEncoder {
+    pub fn encoder(&self) -> CommandEncoder {
         self.device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None })
     }
 
     pub fn begin_render_pass(
-        &mut self,
+        &self,
         frame: &SurfaceTexture,
         encoder: &mut CommandEncoder,
         clear_color: Color,

--- a/visula/src/camera/mod.rs
+++ b/visula/src/camera/mod.rs
@@ -55,7 +55,7 @@ impl Camera {
         }
     }
 
-    pub fn update(&mut self, uniforms: &CameraUniforms, queue: &wgpu::Queue) {
+    pub fn update(&self, uniforms: &CameraUniforms, queue: &wgpu::Queue) {
         queue.write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[*uniforms]));
     }
 }

--- a/visula_core/src/instance_buffer.rs
+++ b/visula_core/src/instance_buffer.rs
@@ -66,7 +66,7 @@ impl<T: Instance + Pod> InstanceBuffer<T> {
         }
     }
 
-    pub fn update(&mut self, device: &Device, queue: &Queue, data: &[T]) {
+    pub fn update(&self, device: &Device, queue: &Queue, data: &[T]) {
         let mut inner = self.inner.borrow_mut();
         log::trace!("Update buffer '{}' with length {}", inner.label, data.len());
         if data.len() == inner.count {

--- a/visula_pyo3/python/visula/__init__.py
+++ b/visula_pyo3/python/visula/__init__.py
@@ -1,5 +1,6 @@
 from ._visula_pyo3 import LineDelegate, SphereDelegate
 from .figure import Figure
 from .expression import Expression
+from .instance_buffer import InstanceBuffer
 
-__all__ = ["LineDelegate", "SphereDelegate", "Figure", "Expression"]
+__all__ = ["LineDelegate", "SphereDelegate", "Figure", "Expression", "InstanceBuffer"]

--- a/visula_pyo3/python/visula/application.py
+++ b/visula_pyo3/python/visula/application.py
@@ -1,11 +1,35 @@
-from ._visula_pyo3 import Application
+from ._visula_pyo3 import PyApplication, PyEventLoop
+from dataclasses import dataclass
 
-_app = None
+_visula_singleton = None
+
+
+@dataclass(frozen=True)
+class VisulaSingleton:
+    application: PyApplication
+    event_loop: PyEventLoop
+
+
+def _init():
+    global _visula_singleton
+    if _visula_singleton is None:
+        event_loop = PyEventLoop()
+        application = PyApplication(event_loop)
+        _visula_singleton = VisulaSingleton(
+            application=application,
+            event_loop=event_loop,
+        )
+
 
 class Visula:
     @staticmethod
     def application():
-        global _app
-        if _app is None:
-            _app = Application()
-        return _app
+        _init()
+        assert _visula_singleton is not None
+        return _visula_singleton.application
+
+    @staticmethod
+    def event_loop():
+        _init()
+        assert _visula_singleton is not None
+        return _visula_singleton.event_loop

--- a/visula_pyo3/python/visula/expression.py
+++ b/visula_pyo3/python/visula/expression.py
@@ -21,6 +21,9 @@ class Expression:
         o = _ensure_expression(other)
         return Expression(self.inner.add(o))
 
+    def __radd__(self, other) -> Expression:
+        return self + other
+
     def __sub__(self, other) -> Expression:
         o = _ensure_expression(other)
         return Expression(self.inner.sub(o))
@@ -28,6 +31,9 @@ class Expression:
     def __mul__(self, other) -> Expression:
         o = _ensure_expression(other)
         return Expression(self.inner.mul(o))
+
+    def __rmul__(self, other) -> Expression:
+        return self + other
 
     def __truediv__(self, other) -> Expression:
         o = _ensure_expression(other)

--- a/visula_pyo3/python/visula/figure.py
+++ b/visula_pyo3/python/visula/figure.py
@@ -3,7 +3,9 @@ from typing import Any, Sequence
 from ._visula_pyo3 import show
 from .application import Visula
 
+
 class Figure:
-    def show(self, renderables: Sequence[Any], callback):
+    def show(self, renderables: Sequence[Any], update):
         app = Visula.application()
-        show(app, renderables, callback)
+        event_loop = Visula.event_loop()
+        show(py_application=app, py_event_loop=event_loop, renderables=renderables, update=update)

--- a/visula_pyo3/python/visula/instance_buffer.py
+++ b/visula_pyo3/python/visula/instance_buffer.py
@@ -1,0 +1,15 @@
+from .application import Visula
+from .expression import Expression
+from ._visula_pyo3 import PyInstanceBuffer
+
+
+class InstanceBuffer(Expression):
+    inner_buffer: PyInstanceBuffer
+
+    def __init__(self, obj):
+        self.inner_buffer = PyInstanceBuffer(pyapplication=Visula.application(), obj=obj)
+        self.inner = self.inner_buffer.instance()
+
+    def update(self, data):
+        application = Visula.application()
+        self.inner_buffer.update_buffer(pyapplication=application, data=data)

--- a/visula_pyo3/src/lib.rs
+++ b/visula_pyo3/src/lib.rs
@@ -1,7 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 use itertools::Itertools;
 
-use pyo3::types::{PyDict, PyFunction};
+use pyo3::types::PyFunction;
 use pyo3::{buffer::PyBuffer, prelude::*};
 
 use visula::{
@@ -12,7 +12,7 @@ use visula::{
 use visula_core::glam::{Vec3, Vec4};
 use visula_derive::Instance;
 use wgpu::Color;
-use winit::event::{ElementState, MouseButton, WindowEvent};
+
 use winit::platform::run_return::EventLoopExtRunReturn;
 use winit::{
     event::Event,
@@ -87,6 +87,74 @@ impl PyExpression {
     }
 }
 
+#[pyclass(unsendable)]
+struct PyInstanceBuffer {
+    inner: InstanceBuffer<PointData>,
+}
+
+#[pymethods]
+impl PyInstanceBuffer {
+    #[new]
+    fn new(py: Python, pyapplication: &PyApplication, obj: PyObject) -> Self {
+        let PyApplication { application, .. } = pyapplication;
+        let x = obj.extract::<PyBuffer<f64>>(py).expect("Could not extract");
+        let buffer = InstanceBuffer::<PointData>::new(&application.device);
+        let point_data: Vec<PointData> = x
+            .to_vec(py)
+            .expect("Cannot convert to vec")
+            .iter()
+            .copied()
+            .chunks(3)
+            .into_iter()
+            .map(|x| {
+                let v: Vec<f64> = x.collect();
+                PointData {
+                    position: [v[0] as f32, v[1] as f32, v[2] as f32],
+                    _padding: Default::default(),
+                }
+            })
+            .collect();
+        buffer.update(&application.device, &application.queue, &point_data);
+        PyInstanceBuffer { inner: buffer }
+    }
+
+    fn update_buffer(
+        &self,
+        py: Python,
+        pyapplication: &PyApplication,
+        data: PyObject,
+    ) -> PyResult<()> {
+        let PyApplication { application, .. } = pyapplication;
+        let x = data
+            .extract::<PyBuffer<f64>>(py)
+            .expect("Could not extract");
+        let point_data: Vec<PointData> = x
+            .to_vec(py)
+            .expect("Cannot convert to vec")
+            .iter()
+            .copied()
+            .chunks(3)
+            .into_iter()
+            .map(|x| {
+                let v: Vec<f64> = x.collect();
+                PointData {
+                    position: [v[0] as f32, v[1] as f32, v[2] as f32],
+                    _padding: Default::default(),
+                }
+            })
+            .collect();
+        self.inner
+            .update(&application.device, &application.queue, &point_data);
+        Ok(())
+    }
+
+    fn instance(&self) -> PyExpression {
+        PyExpression {
+            inner: self.inner.instance().position,
+        }
+    }
+}
+
 #[pyfunction]
 fn convert(py: Python, pyapplication: &PyApplication, obj: PyObject) -> PyExpression {
     let PyApplication { application, .. } = pyapplication;
@@ -102,7 +170,7 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: PyObject) -> PyExpres
         // TODO optimize the case where the same PyBuffer has already
         // been written to a wgpu Buffer, for instance by creating
         // a cache
-        let mut buffer = InstanceBuffer::<PointData>::new(&application.device);
+        let buffer = InstanceBuffer::<PointData>::new(&application.device);
         let instance = buffer.instance();
         let point_data: Vec<PointData> = x
             .to_vec(py)
@@ -129,7 +197,7 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: PyObject) -> PyExpres
         // TODO optimize the case where the same PyBuffer has already
         // been written to a wgpu Buffer, for instance by creating
         // a cache
-        let mut buffer = InstanceBuffer::<PointData>::new(&application.device);
+        let buffer = InstanceBuffer::<PointData>::new(&application.device);
         let instance = buffer.instance();
         let point_data: Vec<PointData> = x
             .to_vec(py)
@@ -169,89 +237,100 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: PyObject) -> PyExpres
     unimplemented!("No support for obj: {obj}")
 }
 
-#[pyclass(name = "Application", unsendable)]
+#[pyclass(unsendable)]
 pub struct PyApplication {
-    event_loop: EventLoop<CustomEvent>,
     application: Application,
+}
+
+#[pyclass(unsendable)]
+pub struct PyEventLoop {
+    event_loop: EventLoop<CustomEvent>,
+}
+
+#[pymethods]
+impl PyEventLoop {
+    #[new]
+    fn new() -> Self {
+        initialize_logger();
+        let event_loop = create_event_loop();
+        Self { event_loop }
+    }
 }
 
 #[pymethods]
 impl PyApplication {
     #[new]
-    fn new() -> Self {
-        initialize_logger();
-        let event_loop = create_event_loop();
+    fn new(event_loop: &PyEventLoop) -> Self {
         let window = create_window(
             RunConfig {
                 canvas_name: "none".to_owned(),
             },
-            &event_loop,
+            &event_loop.event_loop,
         );
         let application = pollster::block_on(async { Application::new(window).await });
-        Self {
-            event_loop,
-            application,
-        }
+        Self { application }
     }
 }
 
 #[pyfunction]
 fn show(
     py: Python,
-    pyapplication: &mut PyApplication,
+    py_event_loop: &mut PyEventLoop,
+    py_application: &PyCell<PyApplication>,
     renderables: Vec<PyObject>,
-    callback: &PyFunction,
+    update: &PyFunction,
 ) -> PyResult<()> {
     // TODO consider making the application retained so that not all the wgpu initialization needs
     // to be re-done
 
-    let spheres_list: Vec<Box<dyn Renderable>> = renderables
-        .iter()
-        .map(|renderable| -> Box<dyn Renderable> {
-            // TODO automate the conversion
-            if let Ok(pysphere) = renderable.extract::<PySphereDelegate>(py) {
-                return Box::new(
-                    Spheres::new(
-                        &pyapplication.application.rendering_descriptor(),
-                        &SphereDelegate {
-                            position: convert(py, pyapplication, pysphere.position).inner,
-                            radius: convert(py, pyapplication, pysphere.radius).inner,
-                            color: convert(py, pyapplication, pysphere.color).inner,
-                        },
-                    )
-                    .expect("Failed to create spheres"),
-                );
-            }
-            if let Ok(pylines) = renderable.extract::<PyLineDelegate>(py) {
-                return Box::new(
-                    Lines::new(
-                        &pyapplication.application.rendering_descriptor(),
-                        &LineDelegate {
-                            start: convert(py, pyapplication, pylines.start).inner,
-                            end: convert(py, pyapplication, pylines.end).inner,
-                            width: convert(py, pyapplication, pylines.width).inner,
-                            alpha: convert(py, pyapplication, pylines.alpha).inner,
-                        },
-                    )
-                    .expect("Failed to create spheres"),
-                );
-            }
-            unimplemented!("TODO")
-        })
-        .collect_vec();
+    let spheres_list: Vec<Box<dyn Renderable>> = {
+        let application = py_application.borrow_mut();
+        renderables
+            .iter()
+            .map(|renderable| -> Box<dyn Renderable> {
+                // TODO automate the conversion
+                if let Ok(pysphere) = renderable.extract::<PySphereDelegate>(py) {
+                    return Box::new(
+                        Spheres::new(
+                            &application.application.rendering_descriptor(),
+                            &SphereDelegate {
+                                position: convert(py, &application, pysphere.position).inner,
+                                radius: convert(py, &application, pysphere.radius).inner,
+                                color: convert(py, &application, pysphere.color).inner,
+                            },
+                        )
+                        .expect("Failed to create spheres"),
+                    );
+                }
+                if let Ok(pylines) = renderable.extract::<PyLineDelegate>(py) {
+                    return Box::new(
+                        Lines::new(
+                            &application.application.rendering_descriptor(),
+                            &LineDelegate {
+                                start: convert(py, &application, pylines.start).inner,
+                                end: convert(py, &application, pylines.end).inner,
+                                width: convert(py, &application, pylines.width).inner,
+                                alpha: convert(py, &application, pylines.alpha).inner,
+                            },
+                        )
+                        .expect("Failed to create spheres"),
+                    );
+                }
+                unimplemented!("TODO")
+            })
+            .collect_vec()
+    };
 
-    let PyApplication {
-        event_loop,
-        application,
-    } = pyapplication;
+    let PyEventLoop { event_loop } = py_event_loop;
 
     event_loop.run_return(move |event, _, control_flow| {
         *control_flow = ControlFlow::Poll;
         match event {
             Event::RedrawEventsCleared => {
-                application.window.request_redraw();
+                py_application.borrow().application.window.request_redraw();
             }
             Event::RedrawRequested(_) => {
+                let application = &py_application.borrow().application;
                 let frame = application.next_frame();
                 let mut encoder = application.encoder();
 
@@ -272,44 +351,51 @@ fn show(
                 frame.present();
             }
             Event::MainEventsCleared => {
-                application.update();
+                let result = update.call((), None);
+                if let Err(err) = result {
+                    println!("Could not call update: {:?}", err);
+                    println!("{}", err.traceback(py).unwrap().format().unwrap());
+                }
+
+                py_application.borrow_mut().application.update();
             }
             event => {
-                if !(application.handle_event(&event, control_flow)) {
-                    if let Event::WindowEvent {
-                        event:
-                            WindowEvent::MouseInput {
-                                state: ElementState::Released,
-                                button: MouseButton::Left,
-                                ..
-                            },
-                        ..
-                    } = event
-                    {
-                        let kwargs = PyDict::new(py);
-                        kwargs.set_item("first", "hello").expect("Failed to insert");
-                        kwargs
-                            .set_item("second", "world")
-                            .expect("Failed to insert");
-                        callback
-                            .call((), Some(kwargs))
-                            .expect("Could not call callback");
-                    }
-                }
+                py_application
+                    .borrow_mut()
+                    .application
+                    .handle_event(&event, control_flow);
             }
         }
     });
     Ok(())
 }
 
+#[pyfunction]
+fn testme(update: &PyFunction) {
+    println!("Called testme");
+    let result = update.call((), None);
+    if let Err(err) = result {
+        println!("Could not call update: {:?}", err);
+    }
+}
+
+#[pyfunction]
+fn testyou() {
+    println!("Called testyou");
+}
+
 #[pymodule]
 #[pyo3(name = "_visula_pyo3")]
 fn visula_pyo3(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(show, m)?)?;
+    m.add_function(wrap_pyfunction!(testme, m)?)?;
+    m.add_function(wrap_pyfunction!(testyou, m)?)?;
     m.add_function(wrap_pyfunction!(convert, m)?)?;
     m.add_class::<PyLineDelegate>()?;
     m.add_class::<PySphereDelegate>()?;
     m.add_class::<PyExpression>()?;
     m.add_class::<PyApplication>()?;
+    m.add_class::<PyEventLoop>()?;
+    m.add_class::<PyInstanceBuffer>()?;
     Ok(())
 }

--- a/visula_pyo3/tests/test_simple.py
+++ b/visula_pyo3/tests/test_simple.py
@@ -1,36 +1,50 @@
-from visula import LineDelegate, SphereDelegate, Figure, Expression
+# from visula._visula_pyo3 import testme, testyou
+
+# def callback():
+    # print("Hello")
+    # testyou()
+
+# testme(callback)
+
+from visula import LineDelegate, SphereDelegate, Figure, Expression, InstanceBuffer
 import numpy as np
 
-t = np.linspace(0, 2*3.14, 10000)
-x = np.cos(t)**3 + t
-y = np.sin(t)**3
-z = np.cos(t)**3
-positions = 10.0 * np.array([x, y, z]).T
+a = 0
+b = 0
+c = 0
+count = 10000
 
-position = Expression(positions)
+def create_particles(a, b, c):
+    a = 10.0 * np.cos(a)
+    b = 100.0 * np.sin(b)
+    c = 50.0 * np.cos(b)
+    d = 8000
+    t = np.linspace(0, 2*3.14, count)
+    x = np.cos(a*t) + np.cos(b*t) / 2.0 + np.sin(c * t) / 3.0 + np.cos(d * t) / 20.0
+    y = np.sin(a*t) + np.sin(b*t) / 2.0 + np.cos(c * t) / 3.0 + np.sin(d * t) / 20.0
+    z = 2.0 * np.cos(t) + np.cos(2 * d * t) / 20.0 + np.sin(2 *d * t) / 20.0
+    positions = 10.0 * np.array([x, y, z]).T
+    return positions
+
+positions = create_particles(a, b, c)
+position = InstanceBuffer(positions)
 
 spheres = SphereDelegate(
     position=position,
-    radius=1.0,
-    color=[1.0, 0.0, 1.0],
+    radius=0.1,
+    color=1.0 * position / 4.0 + 8.0 / 3.0,
 )
-
-t = np.linspace(0, 2*3.14, 10000)
-x = np.sin(t)**3
-y = np.sin(t)**2
-z = np.cos(t)**1
-positions = 10.0 * np.array([x, y, z]).T
 
 fig = Figure()
 
-lines = LineDelegate(
-    start=positions[:-1],
-    end=positions[1:],
-    width=1.0,
-    alpha=1.0,
-)
+def update():
+    global a
+    global b
+    global c
+    a += 0.00001
+    b += 0.000001
+    c += 0.00001
+    positions = create_particles(a, b, c)
+    position.update(positions)
 
-def hello(first, second):
-    print(f"Got {first=} {second=}")
-
-fig.show([spheres, lines], callback=hello)
+fig.show([spheres], update=update)


### PR DESCRIPTION
To achieve this, Application needed to be accessed through PyCell to keep it from being mutably borrowed. In addition, a few cases where Application did not need to use mutable methods were discovered and corrected.