### PR TITLE
Remove unnecessary event loop argument in application

### DIFF
--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -83,7 +83,7 @@ impl Simulation {
 async fn run() {
     initialize_logger();
     let (event_loop, window) = initialize_event_loop_and_window();
-    let mut application = Application::new(Arc::new(window), &event_loop).await;
+    let mut application = Application::new(Arc::new(window)).await;
 
     let mut simulation = Simulation::new(&mut application).expect("Failed to init simulation");
 

--- a/visula/src/application.rs
+++ b/visula/src/application.rs
@@ -14,7 +14,6 @@ use wgpu::{
     Color, CommandEncoder, Device, InstanceDescriptor, SurfaceTexture, TextureFormat, TextureView,
     TextureViewDescriptor,
 };
-use winit::event_loop::EventLoop;
 use winit::{
     event::{Event, WindowEvent},
     window::Window,
@@ -61,13 +60,12 @@ impl EguiRenderer {
         output_depth_format: Option<TextureFormat>,
         msaa_samples: u32,
         window: &Window,
-        event_loop: &EventLoop<CustomEvent>,
     ) -> EguiRenderer {
         let egui_context = Context::default();
         let egui_state = egui_winit::State::new(
             egui_context,
             ViewportId::ROOT,
-            event_loop,
+            window,
             Some(window.scale_factor() as f32),
             None,
         );
@@ -87,7 +85,7 @@ impl EguiRenderer {
 }
 
 impl Application {
-    pub async fn new(window: Arc<Window>, event_loop: &EventLoop<CustomEvent>) -> Application {
+    pub async fn new(window: Arc<Window>) -> Application {
         let size = window.inner_size();
 
         // TODO remove this when https://github.com/gfx-rs/wgpu/issues/1492 is resolved
@@ -159,8 +157,7 @@ impl Application {
         let camera = Camera::new(&device);
 
         let egui_ctx = create_egui_context();
-        let egui_renderer =
-            EguiRenderer::new(&device, surface_view_format, None, 1, &window, event_loop);
+        let egui_renderer = EguiRenderer::new(&device, surface_view_format, None, 1, &window);
 
         Application {
             device,

--- a/visula/src/lib.rs
+++ b/visula/src/lib.rs
@@ -87,7 +87,7 @@ where
     S: Simulation + 'static,
 {
     let main_window_id = window.id();
-    let mut application = Application::new(Arc::new(window), &event_loop).await;
+    let mut application = Application::new(Arc::new(window)).await;
 
     let mut simulation: S = init_simulation(&mut application);
 

--- a/visula_pyo3/src/lib_impl.rs
+++ b/visula_pyo3/src/lib_impl.rs
@@ -560,9 +560,7 @@ impl PyApplication {
             },
             &event_loop.event_loop,
         );
-        let application = pollster::block_on(async {
-            Application::new(Arc::new(window), &event_loop.event_loop).await
-        });
+        let application = pollster::block_on(async { Application::new(Arc::new(window)).await });
         Self { application }
     }
 }


### PR DESCRIPTION
This was introduced when bumping wgpu and switching to egui-wgpu, but it turns out we only need a Window and not an EventLoop to set up egui correctly.