### PR TITLE
Use GL as backend for wasm32

### DIFF
--- a/visula/src/application.rs
+++ b/visula/src/application.rs
@@ -88,7 +88,9 @@ impl Application {
     pub async fn new(window: Arc<Window>) -> Application {
         let size = window.inner_size();
 
-        // TODO remove this when https://github.com/gfx-rs/wgpu/issues/1492 is resolved
+        #[cfg(target_arch = "wasm32")]
+        let backends = wgpu::Backends::GL;
+        #[cfg(not(target_arch = "wasm32"))]
         let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
 
         let dx12_shader_compiler = wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default();


### PR DESCRIPTION
The support for WebGPU is still not good enough across browsers. And the fallback from WebGPU to WebGL fails for instance on Chrome on Linux. For now, we might as well always use GL as the backend when compiling to the web.