### PR TITLE
Move implementation of inject into core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ name = "visula_core"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "env_logger",
  "glam",
  "itertools",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ pyo3 = { version = "0.21" }
 numpy = { version = "0.21", features = ["nalgebra"] }
 pollster = "0.3.0"
 itertools = "0.10.5"
+env_logger = "0.11"
 
 [profile.optimized-dev]
 inherits = "dev"

--- a/visula/Cargo.toml
+++ b/visula/Cargo.toml
@@ -57,7 +57,7 @@ features = [
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pyo3 = {workspace = true}
 numpy = {workspace = true}
-env_logger = "0.11"
+env_logger = {workspace = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"

--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -43,15 +43,10 @@ impl Simulation {
                     let a: Expression = 1.0.into();
                     a + 1.0 + 2.0
                 },
-                start_color: Expression::Vector3 {
+                color: Expression::Vector3 {
                     x: 1.0.into(),
                     y: 1.0.into(),
                     z: 1.0.into(),
-                },
-                end_color: Expression::Vector3 {
-                    x: 0.0.into(),
-                    y: 0.0.into(),
-                    z: 0.0.into(),
                 },
             },
         )

--- a/visula/examples/molecular_dynamics.rs
+++ b/visula/examples/molecular_dynamics.rs
@@ -255,13 +255,8 @@ impl Simulation {
                 start: bond.position_a,
                 end: bond.position_b,
                 width: settings.width,
-                start_color: visula::Expression::Vector3 {
+                color: visula::Expression::Vector3 {
                     x: bond.strength.clone().into(),
-                    y: 1.0.into(),
-                    z: 0.8.into(),
-                },
-                end_color: visula::Expression::Vector3 {
-                    x: bond.strength.into(),
                     y: 1.0.into(),
                     z: 0.8.into(),
                 },

--- a/visula/examples/neuron.rs
+++ b/visula/examples/neuron.rs
@@ -118,13 +118,8 @@ impl Simulation {
                 start: bond.position_a,
                 end: bond.position_b,
                 width: settings.width,
-                start_color: Expression::Vector3 {
+                color: Expression::Vector3 {
                     x: bond.strength.clone().into(),
-                    y: 0.8.into(),
-                    z: 1.0.into(),
-                },
-                end_color: Expression::Vector3 {
-                    x: bond.strength.into(),
                     y: 0.8.into(),
                     z: 1.0.into(),
                 },

--- a/visula/examples/neuronify.rs
+++ b/visula/examples/neuronify.rs
@@ -284,8 +284,7 @@ impl Simulation {
                 start: line.position_a.clone(),
                 end: line.position_b,
                 width: 0.2.into(),
-                start_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
-                end_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
+                color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
             },
         )
         .unwrap();
@@ -298,8 +297,7 @@ impl Simulation {
                 start: boundary.start,
                 end: boundary.end,
                 width: 0.3.into(),
-                start_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
-                end_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
+                color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
             },
         )
         .unwrap();

--- a/visula/examples/wgpu.rs
+++ b/visula/examples/wgpu.rs
@@ -180,8 +180,7 @@ async fn run(event_loop: EventLoop<CustomEvent>, window: Window) {
                 let a: Expression = 1.0.into();
                 a + 1.0 + 2.0
             },
-            start_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
-            end_color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
+            color: glam::Vec3::new(1.0, 0.8, 1.0).into(),
         },
     )
     .unwrap();

--- a/visula/src/render_pass.rs
+++ b/visula/src/render_pass.rs
@@ -6,7 +6,7 @@ pub struct DefaultRenderPassDescriptor<'a> {
     depth_texture: &'a wgpu::TextureView,
 }
 
-impl<'b> DefaultRenderPassDescriptor<'b> {
+impl DefaultRenderPassDescriptor<'_> {
     pub fn new<'a>(
         label: &'a str,
         view: &'a wgpu::TextureView,

--- a/visula_core/Cargo.toml
+++ b/visula_core/Cargo.toml
@@ -13,3 +13,6 @@ uuid = {workspace = true}
 log = {workspace = true}
 bytemuck = {workspace = true}
 itertools = {workspace = true}
+
+[dev-dependencies]
+env_logger = {workspace = true}

--- a/visula_core/src/inject.rs
+++ b/visula_core/src/inject.rs
@@ -1,0 +1,119 @@
+use naga::back::wgsl::WriterFlags;
+use naga::valid::ValidationFlags;
+use naga::{Module, ShaderStage};
+
+use crate::{BindingBuilder, Expression};
+
+macro_rules! entry_point {
+    ($module: ident, $shader_stage: expr) => {
+        $module
+            .entry_points
+            .iter_mut()
+            .find(|e| e.stage == $shader_stage)
+            .expect(&format!("Could not find entry point in shader"))
+    };
+}
+
+pub fn inject(
+    module: &mut Module,
+    binding_builder: &mut BindingBuilder,
+    shader_stage: ShaderStage,
+    variable_name: &str,
+    fields: &[Expression],
+) {
+    let variable = entry_point!(module, shader_stage)
+        .function
+        .local_variables
+        .fetch_if(|variable| variable.name == Some(variable_name.into()))
+        .unwrap_or_else(|| panic!("Could not find variable with name '{variable_name}' in shader"));
+    let variable_expression = entry_point!(module, shader_stage)
+        .function
+        .expressions
+        .fetch_if(|expression| match expression {
+            naga::Expression::LocalVariable(v) => v == &variable,
+            _ => false,
+        })
+        .unwrap();
+
+    let fields_setup = fields
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let expression = value.setup(module, binding_builder);
+            let access_index = entry_point!(module, shader_stage)
+                .function
+                .expressions
+                .append(
+                    naga::Expression::AccessIndex {
+                        index: index as u32,
+                        base: variable_expression,
+                    },
+                    naga::Span::default(),
+                );
+            ::naga::Statement::Store {
+                pointer: access_index,
+                value: expression,
+            }
+        })
+        .collect();
+    let mut new_body = ::naga::Block::from_vec(fields_setup);
+
+    for (statement, span) in entry_point!(module, shader_stage)
+        .function
+        .body
+        .span_iter_mut()
+    {
+        new_body.push(
+            statement.clone(),
+            match span {
+                Some(s) => *s,
+                None => naga::Span::default(),
+            },
+        );
+    }
+    entry_point!(module, shader_stage).function.body = new_body;
+
+    let info =
+        naga::valid::Validator::new(ValidationFlags::empty(), naga::valid::Capabilities::all())
+            .validate(module)
+            .unwrap();
+    let output_str = naga::back::wgsl::write_string(module, &info, WriterFlags::all()).unwrap();
+    log::debug!("Resulting lines shader code:\n{}", output_str);
+}
+
+#[cfg(test)]
+mod tests {
+    use glam::Vec3;
+
+    use super::*;
+
+    #[test]
+    fn test_inject() {
+        env_logger::try_init().unwrap();
+        let mut module =
+            naga::front::wgsl::parse_str(include_str!("./shaders/basic.wgsl")).unwrap();
+        let vertex_fields: Vec<Expression> = vec![
+            Vec3::new(0.0, 0.0, 0.0).into(),
+            Vec3::new(1.0, 0.0, 0.0).into(),
+            1.0.into(),
+        ];
+        let mut binding_builder = BindingBuilder::new(&module, "vs_main", 2);
+        inject(
+            &mut module,
+            &mut binding_builder,
+            ShaderStage::Vertex,
+            "line_vertex",
+            &vertex_fields,
+        );
+
+        let mut binding_builder = BindingBuilder::new(&module, "fs_main", 2);
+        let fragment_fields: Vec<Expression> = vec![Vec3::new(1.0, 1.0, 0.0).into()];
+        inject(
+            &mut module,
+            &mut binding_builder,
+            ShaderStage::Fragment,
+            "line_fragment",
+            &fragment_fields,
+        );
+    }
+}

--- a/visula_core/src/lib.rs
+++ b/visula_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod binding_builder;
+pub mod inject;
 pub mod instance_binding;
 pub mod instance_buffer;
 pub mod naga_type;

--- a/visula_core/src/shaders/basic.wgsl
+++ b/visula_core/src/shaders/basic.wgsl
@@ -16,11 +16,14 @@ struct VertexOutput {
     @location(0) color: vec3<f32>,
 };
 
-struct Line {
+struct LineVertex {
     start: vec3<f32>,
     end: vec3<f32>,
     width: f32,
-    color: vec3<f32>,
+};
+
+struct LineFragment {
+    color: vec4<f32>,
 };
 
 fn offset(pos: vec3<f32>, direction: vec3<f32>, unit_offset: vec3<f32>) -> vec3<f32> {
@@ -34,14 +37,11 @@ fn offset(pos: vec3<f32>, direction: vec3<f32>, unit_offset: vec3<f32>) -> vec3<
 }
 
 fn linef(
-    texture_coordinate: vec2<f32>,
-    line1: Line,
+    length_weight: f32,
+    width_weight: f32,
+    line1: LineVertex,
 ) -> VertexOutput {
-    let length_weight = texture_coordinate.x;
-    let width_weight = texture_coordinate.y;
-
     var output: VertexOutput;
-    output.color = (1.0 - length_weight) * line1.color + length_weight * line1.color;
 
     let width_half = line1.width / 2.0;
     let left = vec3<f32>(-width_half, 0.0, 0.0);
@@ -71,13 +71,15 @@ fn linef(
 
 @vertex
 fn vs_main(
-    @location(0) texture_coordinate: vec2<f32>,
+    @location(0) length_weight: f32,
+    @location(1) width_weight: f32,
 ) -> VertexOutput {
-    var line_input: Line;
-    return linef(texture_coordinate, line_input);
+    var line_vertex: LineVertex;
+    return linef(length_weight, width_weight, line_vertex);
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(input.color, 1.0);
+    var line_fragment: LineFragment;
+    return vec4<f32>(line_fragment.color, 1.0);
 }

--- a/visula_pyo3/src/lib_impl.rs
+++ b/visula_pyo3/src/lib_impl.rs
@@ -604,8 +604,7 @@ fn show(
                                 start: convert(py, &application, pylines.start).inner,
                                 end: convert(py, &application, pylines.end).inner,
                                 width: convert(py, &application, pylines.width).inner,
-                                start_color: convert(py, &application, pylines.start_color).inner,
-                                end_color: convert(py, &application, pylines.end_color).inner,
+                                color: convert(py, &application, pylines.color).inner,
                             },
                         )
                         .expect("Failed to create spheres"),


### PR DESCRIPTION
This reduces the amount of logic present in the Delegate derive macro, which overall simplifies the code. It also makes it possible to test the inject logic itself. For now, the test just ensures the logic runs without issues.