### PR TITLE
Add initial redraw request

### DIFF
--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -137,7 +137,10 @@ impl ApplicationHandler<CustomEvent> for App {
 
     fn user_event(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop, event: CustomEvent) {
         match event {
-            CustomEvent::Application(application) => self.application = Some(application),
+            CustomEvent::Application(application) => {
+                application.window.request_redraw();
+                self.application = Some(application);
+            }
             CustomEvent::DropEvent(_) => {}
         }
     }

--- a/visula/src/lib.rs
+++ b/visula/src/lib.rs
@@ -140,7 +140,10 @@ where
 
     fn user_event(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop, event: CustomEvent) {
         match event {
-            CustomEvent::Application(application) => self.application = Some(application),
+            CustomEvent::Application(application) => {
+                application.window.request_redraw();
+                self.application = Some(application);
+            }
             CustomEvent::DropEvent(_) => {}
         }
     }


### PR DESCRIPTION
This was missing and meant that most examples would not start until the Window was otherwised requested to redraw, such as when resized.