### PR TITLE
Make the API more ergonomic for basic visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,38 @@ This means that there is only one array `t` uploaded to the GPU.
 
 ## Rust example
 
+The same visualization in Rust:
+
 ```rust
-use visula::{Expression, InstanceDeviceExt, SphereGeometry, SphereMaterial, Spheres};
+use visula::{vec3, InstanceBuffer, SphereGeometry, SphereMaterial, Spheres};
 use visula_derive::Instance;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, bytemuck::Pod, bytemuck::Zeroable)]
 struct Particle {
-    position: glam::Vec3,
-    _padding: f32,
+    t: f32,
 }
 
-let buffer = application.device.create_instance_buffer::<Particle>();
-let particle = buffer.instance();
+let data: Vec<Particle> = (0..100_000)
+    .map(|i| Particle { t: i as f32 * 0.001 })
+    .collect();
+let buffer = InstanceBuffer::new_with_init(&application.device, &data);
+let t = buffer.instance().t;
 
+let position = 10.0 * vec3(t.cos(), t.sin(), t);
 let spheres = Spheres::new(
     &application.rendering_descriptor(),
     &SphereGeometry {
-        position: particle.position,
-        radius: 0.5.into(),
-        color: Expression::Position * 0.1 + 0.5,
+        position: position.clone(),
+        radius: 0.2.into(),
+        color: position / 4.0,
     },
-    &SphereMaterial { color: Expression::InputColor.lit() },
-)?;
+    &SphereMaterial::default(),
+)
+.unwrap();
 ```
+
+See [visula/examples/spheres.rs](visula/examples/spheres.rs) for the full runnable version.
 
 ![Molecular dynamics](screenshots/molecular_dynamics.png)
 
@@ -74,6 +82,7 @@ let spheres = Spheres::new(
 
 ```bash
 # Native Rust
+cargo run --example spheres
 cargo run --example showcase
 cargo run --example molecular_dynamics
 cargo run --example neuron

--- a/visula/examples/clay.rs
+++ b/visula/examples/clay.rs
@@ -308,9 +308,6 @@ fn generate(count: usize) -> Vec<Particle> {
     current_particles
 }
 
-#[derive(Debug)]
-struct Error {}
-
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Uniform, Zeroable)]
 struct Settings {
@@ -326,7 +323,7 @@ struct Simulation {
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let cli = Cli::parse();
         let count = cli.count.unwrap_or(6);
         let particles = generate(count);
@@ -352,17 +349,16 @@ impl Simulation {
         )
         .unwrap();
 
-        Ok(Simulation {
+        Simulation {
             particles,
             spheres,
             particle_buffer,
             rendering_controls: RenderingControls::new(),
-        })
+        }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
     fn update(&mut self, application: &mut visula::Application) {
         self.rendering_controls.update(application);
         let previous_particles = self.particles.clone();
@@ -400,5 +396,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/debug_cylinder.rs
+++ b/visula/examples/debug_cylinder.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use glam::{Quat, Vec3};
+use glam::Vec3;
 
 use visula::{
     primitives::generate_torus, CylinderGeometry, CylinderMaterial, Cylinders, Expression,
@@ -8,9 +8,8 @@ use visula::{
     SpherePrimitive, Spheres,
 };
 use visula_derive::Instance;
-use wgpu::util::DeviceExt;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct CylinderData {
     start: [f32; 3],
@@ -18,7 +17,6 @@ struct CylinderData {
     end: [f32; 3],
     end_radius: f32,
     color: [f32; 3],
-    _pad: f32,
 }
 
 struct Simulation {
@@ -42,7 +40,6 @@ impl Simulation {
             end: [0.0, 3.0, 0.0],
             end_radius: 0.2,
             color: [0.8, 0.2, 0.2],
-            _pad: 0.0,
         }];
         cyl_buffer.update(device, &app.queue, &cyl_data);
 
@@ -69,25 +66,12 @@ impl Simulation {
             &app.rendering_descriptor(),
             &MeshGeometry {
                 position: Vec3::new(0.0, -1.0, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
+                ..Default::default()
             },
-            &MeshMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &MeshMaterial::default(),
         )
         .unwrap();
-        torus_mesh.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Torus vertex buffer"),
-            contents: bytemuck::cast_slice(&torus_verts),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        torus_mesh.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Torus index buffer"),
-            contents: bytemuck::cast_slice(&torus_indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        torus_mesh.vertex_count = torus_indices.len();
+        torus_mesh.set_mesh_data(device, &torus_verts, &torus_indices);
 
         // Sphere primitives (ray-traced) with .toon_lit()
         let soma_data = vec![
@@ -95,13 +79,11 @@ impl Simulation {
                 position: [-4.0, 1.0, 0.0],
                 radius: 1.0,
                 color: [1.0, 0.39, 0.20],
-                padding: 0.0,
             },
             SpherePrimitive {
                 position: [4.0, 1.0, 0.0],
                 radius: 1.0,
                 color: [0.39, 0.78, 0.20],
-                padding: 0.0,
             },
         ];
         let soma_buffer: InstanceBuffer<SpherePrimitive> = device.create_instance_buffer();
@@ -140,8 +122,6 @@ impl Simulation {
 }
 
 impl visula::Simulation for Simulation {
-    type Error = ();
-
     fn update(&mut self, application: &mut visula::Application) {
         self.rendering_controls.update(application);
     }

--- a/visula/examples/gltf_viewer.rs
+++ b/visula/examples/gltf_viewer.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 
-use glam::{Quat, Vec3};
 use std::io::BufReader;
 
 use clap::Parser;
@@ -53,11 +52,7 @@ impl Simulation {
                 };
                 let mut mesh_pipeline = MeshPipeline::new(
                     &application.rendering_descriptor(),
-                    &MeshGeometry {
-                        position: Vec3::new(0.0, 0.0, 0.0).into(),
-                        rotation: Quat::IDENTITY.into(),
-                        scale: Vec3::ONE.into(),
-                    },
+                    &MeshGeometry::default(),
                     &MeshMaterial {
                         color: color_expression,
                     },
@@ -83,8 +78,6 @@ impl Simulation {
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
-
     fn update(&mut self, _application: &mut visula::Application) {}
 
     fn render(&mut self, data: &mut RenderData) {

--- a/visula/examples/grid.rs
+++ b/visula/examples/grid.rs
@@ -2,22 +2,18 @@ use bytemuck::{Pod, Zeroable};
 use glam::{Vec3, Vec4};
 use itertools::iproduct;
 use visula::{
-    CustomEvent, Expression, InstanceBuffer, LineGeometry, LineMaterial, Lines, RenderData,
+    vec3, CustomEvent, Expression, InstanceBuffer, LineGeometry, LineMaterial, Lines, RenderData,
     Renderable, UniformBuffer,
 };
 use visula_derive::{Instance, Uniform};
 use winit::event::{Event, WindowEvent};
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct LineData {
     position_a: [f32; 3],
     position_b: [f32; 3],
-    _padding: [f32; 2],
 }
-
-#[derive(Debug)]
-struct Error {}
 
 struct Simulation {
     lines: Lines,
@@ -35,15 +31,12 @@ struct Uniforms {
 }
 
 fn gaussian(a: &Expression, b: &Expression) -> Expression {
-    Expression::Vector3 {
-        x: 0.0.into(),
-        y: (10.0 * &(-((a - b).length()).pow(2.0) / (2.0 * 8.0)).exp()).into(),
-        z: 0.0.into(),
-    }
+    let distance = (a - b).length();
+    vec3(0.0, 10.0 * (-distance.pow(2.0) / (2.0 * 8.0)).exp(), 0.0)
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let column_count = 100;
         let row_count = 100;
         let columns = 0..column_count;
@@ -60,7 +53,6 @@ impl Simulation {
                     0.0,
                     offset[1] + row as f32 + direction[1],
                 ],
-                _padding: [0.0, 0.0],
             })
             .collect();
 
@@ -84,24 +76,21 @@ impl Simulation {
                 width: 0.1.into(),
                 color: Vec3::ZERO.into(),
             },
-            &LineMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &LineMaterial::default(),
         )
         .unwrap();
 
-        Ok(Simulation {
+        Simulation {
             lines,
             line_buffer,
             line_data,
             uniforms_data,
             uniforms_buffer,
-        })
+        }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
     fn update(&mut self, application: &mut visula::Application) {
         self.line_buffer
             .update(&application.device, &application.queue, &self.line_data);
@@ -148,5 +137,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/line.rs
+++ b/visula/examples/line.rs
@@ -1,20 +1,16 @@
 use bytemuck::{Pod, Zeroable};
 use visula::{
-    Expression, InstanceBuffer, InstanceDeviceExt, LineGeometry, LineMaterial, Lines, RenderData,
+    vec3, InstanceBuffer, InstanceDeviceExt, LineGeometry, LineMaterial, Lines, RenderData,
     Renderable,
 };
 use visula_derive::Instance;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct LineData {
     position_a: [f32; 3],
     position_b: [f32; 3],
-    _padding: [f32; 2],
 }
-
-#[derive(Debug)]
-struct Error {}
 
 struct Simulation {
     lines: Lines,
@@ -23,7 +19,7 @@ struct Simulation {
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let line_buffer = application.device.create_instance_buffer::<LineData>();
         let line = line_buffer.instance();
 
@@ -33,35 +29,26 @@ impl Simulation {
                 start: line.position_a,
                 end: line.position_b,
                 width: 0.5.into(),
-                color: Expression::Vector3 {
-                    x: 0.8.into(),
-                    y: 0.8.into(),
-                    z: 0.8.into(),
-                },
+                color: vec3(0.8, 0.8, 0.8),
             },
-            &LineMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &LineMaterial::default(),
         )
         .unwrap();
 
         let line_data = vec![LineData {
             position_a: [-10.0, 0.0, 0.0],
             position_b: [10.0, 0.0, 0.0],
-            _padding: [0.0; 2],
         }];
 
-        Ok(Simulation {
+        Simulation {
             lines,
             line_buffer,
             line_data,
-        })
+        }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
-
     fn update(&mut self, application: &mut visula::Application) {
         self.line_buffer
             .update(&application.device, &application.queue, &self.line_data);
@@ -73,5 +60,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/mesh.rs
+++ b/visula/examples/mesh.rs
@@ -1,9 +1,7 @@
-use glam::{Quat, Vec3};
+use glam::Vec3;
 use visula::{
-    primitives::mesh_primitive::MeshVertexAttributes, Expression, MeshGeometry, MeshMaterial,
-    MeshPipeline,
+    primitives::mesh_primitive::MeshVertexAttributes, MeshGeometry, MeshMaterial, MeshPipeline,
 };
-use wgpu::util::DeviceExt;
 
 const PI: f32 = std::f32::consts::PI;
 
@@ -79,36 +77,18 @@ impl MeshExample {
 
         let mut mesh = MeshPipeline::new(
             &app.rendering_descriptor(),
-            &MeshGeometry {
-                position: Vec3::ZERO.into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
-            },
-            &MeshMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &MeshGeometry::default(),
+            &MeshMaterial::default(),
         )
         .unwrap();
 
-        mesh.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Trefoil vertex buffer"),
-            contents: bytemuck::cast_slice(&vertices),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        mesh.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Trefoil index buffer"),
-            contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        mesh.vertex_count = indices.len();
+        mesh.set_mesh_data(device, &vertices, &indices);
 
         Self { mesh }
     }
 }
 
 impl visula::Simulation for MeshExample {
-    type Error = ();
-
     fn render(&mut self, data: &mut visula::RenderData) {
         self.mesh.render(data);
     }

--- a/visula/examples/molecular_dynamics.rs
+++ b/visula/examples/molecular_dynamics.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use itertools_num::linspace;
 use visula::Renderable;
 use visula::{
-    Expression, InstanceBuffer, InstanceDeviceExt, LineGeometry, LineMaterial, Lines, RenderData,
+    vec3, InstanceBuffer, InstanceDeviceExt, LineGeometry, LineMaterial, Lines, RenderData,
     SphereGeometry, SphereMaterial, Spheres, UniformBuffer,
 };
 use visula_derive::{Instance, Uniform};
@@ -17,23 +17,21 @@ struct Cli {
     count: Option<usize>,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable)]
 struct Particle {
     position: glam::Vec3,
     velocity: glam::Vec3,
     acceleration: glam::Vec3,
     mass: f32,
-    _padding: [f32; 2],
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct BondData {
     position_a: [f32; 3],
     position_b: [f32; 3],
     strength: f32,
-    _padding: f32,
 }
 
 trait TwoBodyForce {
@@ -107,7 +105,6 @@ fn integrate<F: TwoBodyForce>(
                     position_a: (*position_i).into(),
                     position_b: (*position_j).into(),
                     strength,
-                    _padding: 0.0,
                 });
             }
         }
@@ -165,16 +162,12 @@ fn generate(count: usize) -> Vec<Particle> {
                     velocity: Vec3::new(0.0, 0.0, 0.0),
                     acceleration: Vec3::new(0.0, 0.0, 0.0),
                     mass: 1.0,
-                    _padding: [0.0; 2],
                 })
             }
         }
     }
     current_particles
 }
-
-#[derive(Debug)]
-struct Error {}
 
 #[repr(C, align(16))]
 #[derive(Copy, Clone, Debug, Pod, Uniform, Zeroable)]
@@ -185,11 +178,10 @@ struct Settings {
     _padding: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable)]
 struct ColorData {
     value: glam::Vec3,
-    _padding: f32,
 }
 
 struct BoundingBox {
@@ -212,7 +204,7 @@ struct Simulation {
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let cli = Cli::parse();
         let count = cli.count.unwrap_or(8);
         let particles = generate(count);
@@ -235,7 +227,6 @@ impl Simulation {
         let color_data = (0..(count.pow(3)))
             .map(|_| ColorData {
                 value: Vec3::new(1.0, 0.5, 1.0),
-                _padding: Default::default(),
             })
             .collect_vec();
         let color_buffer = application.device.create_instance_buffer::<ColorData>();
@@ -248,9 +239,7 @@ impl Simulation {
                 radius: 1.0 + settings.radius,
                 color: color.value,
             },
-            &SphereMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &SphereMaterial::default(),
         )
         .unwrap();
 
@@ -260,20 +249,14 @@ impl Simulation {
                 start: bond.position_a,
                 end: bond.position_b,
                 width: settings.width,
-                color: Expression::Vector3 {
-                    x: bond.strength.clone().into(),
-                    y: 1.0.into(),
-                    z: 0.8.into(),
-                },
+                color: vec3(bond.strength, 1.0, 0.8),
             },
-            &LineMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &LineMaterial::default(),
         )
         .unwrap();
 
         let bound = count as f32 * 3.0;
-        Ok(Simulation {
+        Simulation {
             particles,
             spheres,
             particle_buffer,
@@ -288,7 +271,7 @@ impl Simulation {
             count,
             target_temperature: 10.0,
             last_update: Utc::now(),
-        })
+        }
     }
 
     fn reset(&mut self) {
@@ -297,7 +280,6 @@ impl Simulation {
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
     fn update(&mut self, application: &mut visula::Application) {
         let mut bond_data = Vec::new();
         let current_time = Utc::now();
@@ -360,5 +342,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/neuron.rs
+++ b/visula/examples/neuron.rs
@@ -4,7 +4,7 @@ use visula::Renderable;
 
 use glam::{Vec3, Vec4};
 use visula::{
-    CustomEvent, Expression, InstanceBuffer, LineGeometry, LineMaterial, Lines, RenderData,
+    vec3, CustomEvent, InstanceBuffer, LineGeometry, LineMaterial, Lines, RenderData,
     SphereGeometry, SphereMaterial, Spheres, UniformBuffer,
 };
 use visula_derive::{Instance, Uniform};
@@ -13,7 +13,7 @@ use winit::{
     event::{ElementState, Event, MouseButton, WindowEvent},
 };
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable)]
 struct Compartment {
     position: Vec3,
@@ -25,23 +25,21 @@ struct Compartment {
     n: f32,
     influence: f32,
     capacitance: f32,
-    _padding: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable)]
 struct Particle {
     position: glam::Vec3,
     voltage: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct BondData {
     position_a: Vec3,
     position_b: Vec3,
     strength: f32,
-    _padding: f32,
 }
 
 fn lennard_jones(position_a: Vec3, position_b: Vec3, eps: f32, sigma: f32) -> Vec3 {
@@ -52,9 +50,6 @@ fn lennard_jones(position_a: Vec3, position_b: Vec3, eps: f32, sigma: f32) -> Ve
         * eps.powi(24)
         * (2.0 * sigma.powi(12) / r_l.powi(12) - sigma.powi(6) / r_l.powi(6))
 }
-
-#[derive(Debug)]
-struct Error {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Uniform, Zeroable)]
@@ -82,7 +77,7 @@ struct Simulation {
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let particle_buffer = InstanceBuffer::<Particle>::new(&application.device);
         let particle = particle_buffer.instance();
 
@@ -97,21 +92,19 @@ impl Simulation {
         };
         let settings_buffer = UniformBuffer::new_with_init(&application.device, &settings_data);
         let settings = settings_buffer.uniform();
-        let pos = &particle.position;
+        let voltage_color = (particle.voltage + 10.0) / 120.0;
         let spheres = Spheres::new(
             &application.rendering_descriptor(),
             &SphereGeometry {
-                position: pos.clone(),
+                position: particle.position,
                 radius: settings.radius,
-                color: Expression::Vector3 {
-                    x: (0.1 + (particle.voltage.clone() + 10.0) / 120.0).into(),
-                    y: (0.2 + (particle.voltage.clone() + 10.0) / 120.0).into(),
-                    z: (0.3 + (particle.voltage.clone() + 10.0) / 120.0).into(),
-                },
+                color: vec3(
+                    0.1 + &voltage_color,
+                    0.2 + &voltage_color,
+                    0.3 + &voltage_color,
+                ),
             },
-            &SphereMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &SphereMaterial::default(),
         )
         .unwrap();
 
@@ -121,15 +114,9 @@ impl Simulation {
                 start: bond.position_a,
                 end: bond.position_b,
                 width: settings.width,
-                color: Expression::Vector3 {
-                    x: bond.strength.clone().into(),
-                    y: 0.8.into(),
-                    z: 1.0.into(),
-                },
+                color: vec3(bond.strength, 0.8, 1.0),
             },
-            &LineMaterial {
-                color: Expression::InputColor.lit(),
-            },
+            &LineMaterial::default(),
         )
         .unwrap();
 
@@ -144,7 +131,6 @@ impl Simulation {
             n: 0.38079754,
             influence: 0.0,
             capacitance: 4.0,
-            _padding: Default::default(),
         });
         compartments.insert(Compartment {
             position: Vec3::new(2.0, 0.0, 0.0),
@@ -156,7 +142,6 @@ impl Simulation {
             n: 0.38079754,
             influence: 0.0,
             capacitance: 4.0,
-            _padding: Default::default(),
         });
         compartments.insert(Compartment {
             position: Vec3::new(2.0, 0.0, 2.0),
@@ -168,10 +153,9 @@ impl Simulation {
             n: 0.38079754,
             influence: 0.0,
             capacitance: 4.0,
-            _padding: Default::default(),
         });
 
-        Ok(Simulation {
+        Simulation {
             particles: vec![],
             spheres,
             particle_buffer,
@@ -181,12 +165,11 @@ impl Simulation {
             settings_buffer,
             compartments,
             mouse: Mouse { position: None },
-        })
+        }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
     fn update(&mut self, application: &mut visula::Application) {
         let compartments = &mut self.compartments;
         let injecting_current = false;
@@ -318,7 +301,6 @@ impl visula::Simulation for Simulation {
                             position_a: compartment_a.position,
                             position_b: compartment_b.position,
                             strength: 0.5 + value,
-                            _padding: 0.0,
                         });
                     }
                 }
@@ -415,7 +397,6 @@ impl visula::Simulation for Simulation {
                     n: 0.38079754,
                     influence: 0.0,
                     capacitance: 4.0,
-                    _padding: 0.0,
                 });
             }
             Event::WindowEvent {
@@ -431,5 +412,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/neuronify.rs
+++ b/visula/examples/neuronify.rs
@@ -185,12 +185,11 @@ struct StimulationTool {
     position: Vec3,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable)]
 struct Sphere {
     position: glam::Vec3,
     color: glam::Vec3,
-    _padding: [f32; 2],
 }
 
 struct Mouse {
@@ -218,9 +217,6 @@ struct Simulation {
     mesh: MeshPipeline,
 }
 
-#[derive(Debug)]
-struct Error {}
-
 #[derive(Clone, Debug)]
 enum Input {
     Repulsion { min_angle: f32, max_angle: f32 },
@@ -234,21 +230,19 @@ enum Output {
     TurnRight,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct BondData {
     position_a: Vec3,
     position_b: Vec3,
     strength: f32,
-    _padding: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct LineData {
     start: Vec3,
     end: Vec3,
-    _padding: [f32; 2],
 }
 
 #[repr(C, align(16))]
@@ -316,22 +310,18 @@ impl Simulation {
             LineData {
                 start: Vec3::new(-BOUNDARY, 0.0, -BOUNDARY),
                 end: Vec3::new(BOUNDARY, 0.0, -BOUNDARY),
-                _padding: Default::default(),
             },
             LineData {
                 start: Vec3::new(-BOUNDARY, 0.0, -BOUNDARY),
                 end: Vec3::new(-BOUNDARY, 0.0, BOUNDARY),
-                _padding: Default::default(),
             },
             LineData {
                 start: Vec3::new(BOUNDARY, 0.0, -BOUNDARY),
                 end: Vec3::new(BOUNDARY, 0.0, BOUNDARY),
-                _padding: Default::default(),
             },
             LineData {
                 start: Vec3::new(-BOUNDARY, 0.0, BOUNDARY),
                 end: Vec3::new(BOUNDARY, 0.0, BOUNDARY),
-                _padding: Default::default(),
             },
         ];
 
@@ -689,7 +679,6 @@ impl Simulation {
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
     fn update(&mut self, application: &mut visula::Application) {
         let Simulation {
             connection_tool,
@@ -936,7 +925,6 @@ impl visula::Simulation for Simulation {
                 Sphere {
                     position: position.position,
                     color,
-                    _padding: Default::default(),
                 }
             })
             .collect();
@@ -980,7 +968,6 @@ impl visula::Simulation for Simulation {
                 Some(Sphere {
                     position,
                     color: Vec3::new(0.8, 0.9, 0.9),
-                    _padding: Default::default(),
                 })
             })
             .collect();
@@ -1005,7 +992,6 @@ impl visula::Simulation for Simulation {
                     position_a: start,
                     position_b: end,
                     strength: connection.strength as f32,
-                    _padding: Default::default(),
                 }
             })
             .collect();
@@ -1015,7 +1001,6 @@ impl visula::Simulation for Simulation {
                 position_a: connection.start,
                 position_b: connection.end,
                 strength: 1.0,
-                _padding: Default::default(),
             });
         }
 
@@ -1074,5 +1059,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(Simulation::new); //.expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/painter.rs
+++ b/visula/examples/painter.rs
@@ -17,7 +17,6 @@ impl Simulation {
 }
 
 impl visula::Simulation for Simulation {
-    type Error = visula::error::Error;
     fn update(&mut self, application: &mut visula::Application) {
         self.painter.spheres(&[Sphere {
             position: Vec3::ZERO,

--- a/visula/examples/plane.rs
+++ b/visula/examples/plane.rs
@@ -1,10 +1,9 @@
-use glam::{Quat, Vec3};
+use glam::Vec3;
 use visula::{
     primitives::mesh_primitive::MeshVertexAttributes, Expression, MeshGeometry, MeshMaterial,
     MeshPipeline,
 };
 use visula_core::TextureBuffer;
-use wgpu::util::DeviceExt;
 
 struct PlaneExample {
     mesh: MeshPipeline,
@@ -24,9 +23,8 @@ impl PlaneExample {
         let mut mesh = MeshPipeline::new(
             &app.rendering_descriptor(),
             &MeshGeometry {
-                position: Vec3::ZERO.into(),
-                rotation: Quat::IDENTITY.into(),
                 scale: (100.0 * Vec3::ONE).into(),
+                ..Default::default()
             },
             &MeshMaterial {
                 color: texture.sample(&Expression::UV),
@@ -63,17 +61,7 @@ impl PlaneExample {
 
         let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
 
-        mesh.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Textured plane vertex buffer"),
-            contents: bytemuck::cast_slice(&vertices),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        mesh.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Textured plane index buffer"),
-            contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        mesh.vertex_count = indices.len();
+        mesh.set_mesh_data(device, &vertices, &indices);
 
         let width: u32 = size.width;
         let height: u32 = size.height;
@@ -100,8 +88,6 @@ impl PlaneExample {
 }
 
 impl visula::Simulation for PlaneExample {
-    type Error = ();
-
     fn render(&mut self, data: &mut visula::RenderData) {
         self.mesh.render(data);
     }

--- a/visula/examples/showcase.rs
+++ b/visula/examples/showcase.rs
@@ -1,21 +1,19 @@
 use bytemuck::{Pod, Zeroable};
-use glam::{Quat, Vec3, Vec4};
+use glam::{Vec3, Vec4};
 
 use visula::{
-    primitives::mesh_primitive::MeshVertexAttributes, Expression, InstanceBuffer,
+    primitives::mesh_primitive::MeshVertexAttributes, vec3, Expression, InstanceBuffer,
     InstanceDeviceExt, LineGeometry, LineMaterial, Lines, MeshGeometry, MeshMaterial, MeshPipeline,
     RenderData, Renderable, RenderingControls, ShadowRenderData, SphereGeometry, SphereMaterial,
     SpherePrimitive, Spheres,
 };
 use visula_derive::Instance;
-use wgpu::util::DeviceExt;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct LineData {
     start: [f32; 3],
     end: [f32; 3],
-    _padding: [f32; 2],
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -66,9 +64,6 @@ struct Simulation {
     rendering_controls: RenderingControls,
 }
 
-#[derive(Debug)]
-struct Error {}
-
 fn create_sphere_variant(
     app: &visula::Application,
     sphere_buffer: &InstanceBuffer<SpherePrimitive>,
@@ -87,7 +82,7 @@ fn create_sphere_variant(
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         let sphere_buffer: InstanceBuffer<SpherePrimitive> =
             application.device.create_instance_buffer();
 
@@ -129,7 +124,7 @@ impl Simulation {
                     start: line.start,
                     end: line.end,
                     width: 0.3.into(),
-                    color: Vec3::new(0.8, 0.8, 0.8).into(),
+                    color: vec3(0.8, 0.8, 0.8),
                 },
                 &LineMaterial { color: color_expr },
             )
@@ -163,7 +158,6 @@ impl Simulation {
             .map(|pair| LineData {
                 start: pair[0],
                 end: pair[1],
-                _padding: [0.0; 2],
             })
             .collect();
         line_buffer.update(&application.device, &application.queue, &line_data);
@@ -172,8 +166,7 @@ impl Simulation {
             &application.rendering_descriptor(),
             &MeshGeometry {
                 position: Vec3::new(4.0, 0.0, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
+                ..Default::default()
             },
             &MeshMaterial {
                 color: Expression::from(Vec4::new(0.8, 0.3, 0.2, 1.0)).lit(),
@@ -185,8 +178,7 @@ impl Simulation {
             &application.rendering_descriptor(),
             &MeshGeometry {
                 position: Vec3::new(0.0, -2.0, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
+                ..Default::default()
             },
             &MeshMaterial {
                 color: Expression::from(Vec4::new(0.9, 0.9, 0.9, 1.0)).lit(),
@@ -222,23 +214,7 @@ impl Simulation {
             },
         ];
         let ground_indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
-        ground.vertex_buffer =
-            application
-                .device
-                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("Ground vertex buffer"),
-                    contents: bytemuck::cast_slice(&ground_vertices),
-                    usage: wgpu::BufferUsages::VERTEX,
-                });
-        ground.index_buffer =
-            application
-                .device
-                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("Ground index buffer"),
-                    contents: bytemuck::cast_slice(&ground_indices),
-                    usage: wgpu::BufferUsages::INDEX,
-                });
-        ground.vertex_count = ground_indices.len();
+        ground.set_mesh_data(&application.device, &ground_vertices, &ground_indices);
 
         let sphere_data: Vec<SpherePrimitive> = sphere_positions
             .iter()
@@ -253,12 +229,11 @@ impl Simulation {
                 position: *pos,
                 radius: *radius,
                 color: *color,
-                padding: 0.0,
             })
             .collect();
         sphere_buffer.update(&application.device, &application.queue, &sphere_data);
 
-        Ok(Simulation {
+        Simulation {
             color_mode: ColorMode::Lit,
             sphere_variants,
             _sphere_buffer: sphere_buffer,
@@ -267,13 +242,11 @@ impl Simulation {
             mesh,
             ground,
             rendering_controls: RenderingControls::new(),
-        })
+        }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
-
     fn update(&mut self, application: &mut visula::Application) {
         self.rendering_controls.update(application);
     }
@@ -327,5 +300,5 @@ impl visula::Simulation for Simulation {
 }
 
 fn main() {
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/examples/spheres.rs
+++ b/visula/examples/spheres.rs
@@ -1,0 +1,55 @@
+use bytemuck::{Pod, Zeroable};
+use visula::{
+    vec3, InstanceBuffer, RenderData, Renderable, SphereGeometry, SphereMaterial, Spheres,
+};
+use visula_derive::Instance;
+
+#[repr(C)]
+#[derive(Clone, Copy, Instance, Pod, Zeroable)]
+struct Particle {
+    t: f32,
+}
+
+struct Simulation {
+    spheres: Spheres,
+    _buffer: InstanceBuffer<Particle>,
+}
+
+impl Simulation {
+    fn new(application: &mut visula::Application) -> Simulation {
+        let data: Vec<Particle> = (0..100_000)
+            .map(|i| Particle {
+                t: i as f32 * 0.001,
+            })
+            .collect();
+        let buffer = InstanceBuffer::new_with_init(&application.device, &data);
+        let t = buffer.instance().t;
+
+        let position = 10.0 * vec3(t.cos(), t.sin(), t);
+        let spheres = Spheres::new(
+            &application.rendering_descriptor(),
+            &SphereGeometry {
+                position: position.clone(),
+                radius: 0.2.into(),
+                color: position / 4.0,
+            },
+            &SphereMaterial::default(),
+        )
+        .unwrap();
+
+        Simulation {
+            spheres,
+            _buffer: buffer,
+        }
+    }
+}
+
+impl visula::Simulation for Simulation {
+    fn render(&mut self, data: &mut RenderData) {
+        self.spheres.render(data);
+    }
+}
+
+fn main() {
+    visula::run(Simulation::new);
+}

--- a/visula/examples/svg_icons.rs
+++ b/visula/examples/svg_icons.rs
@@ -20,9 +20,6 @@ struct Args {
     svg_path: PathBuf,
 }
 
-#[derive(Debug)]
-struct Error {}
-
 struct RenderedPath {
     polygons: Polygons,
 }
@@ -126,7 +123,7 @@ struct Simulation {
 }
 
 impl Simulation {
-    fn new(application: &mut visula::Application, svg_path: &PathBuf) -> Result<Self, Error> {
+    fn new(application: &mut visula::Application, svg_path: &PathBuf) -> Self {
         let svg_data = std::fs::read(svg_path).expect("Failed to read SVG file");
         let tree =
             Tree::from_data(&svg_data, &usvg::Options::default()).expect("Failed to parse SVG");
@@ -162,7 +159,7 @@ impl Simulation {
             );
         }
 
-        Ok(Simulation { rendered_paths })
+        Simulation { rendered_paths }
     }
 }
 
@@ -256,8 +253,6 @@ fn process_node_with_scale(
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
-
     fn render(&mut self, data: &mut RenderData) {
         for path in &self.rendered_paths {
             path.polygons.render(data);
@@ -275,7 +270,5 @@ impl visula::Simulation for Simulation {
 fn main() {
     let args = Args::parse();
     let svg_path = args.svg_path.clone();
-    visula::run(move |app| {
-        Simulation::new(app, &svg_path).expect("Failed to initialize SVG viewer")
-    });
+    visula::run(move |app| Simulation::new(app, &svg_path));
 }

--- a/visula/examples/texture.rs
+++ b/visula/examples/texture.rs
@@ -1,10 +1,9 @@
-use glam::{Quat, Vec3};
+use glam::Vec3;
 use visula::{
     primitives::mesh_primitive::MeshVertexAttributes, Expression, MeshGeometry, MeshMaterial,
     MeshPipeline,
 };
 use visula_core::TextureBuffer;
-use wgpu::util::DeviceExt;
 
 const PI: f32 = std::f32::consts::PI;
 
@@ -106,36 +105,20 @@ impl TextureExample {
 
         let mut mesh = MeshPipeline::new(
             &app.rendering_descriptor(),
-            &MeshGeometry {
-                position: Vec3::ZERO.into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
-            },
+            &MeshGeometry::default(),
             &MeshMaterial {
                 color: texture.sample(&Expression::UV).lit(),
             },
         )
         .unwrap();
 
-        mesh.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Trefoil vertex buffer"),
-            contents: bytemuck::cast_slice(&vertices),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        mesh.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Trefoil index buffer"),
-            contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        mesh.vertex_count = indices.len();
+        mesh.set_mesh_data(device, &vertices, &indices);
 
         Self { mesh }
     }
 }
 
 impl visula::Simulation for TextureExample {
-    type Error = ();
-
     fn render(&mut self, data: &mut visula::RenderData) {
         self.mesh.render(data);
     }

--- a/visula/examples/toon_neurons.rs
+++ b/visula/examples/toon_neurons.rs
@@ -10,9 +10,8 @@ use visula::{
     ShadowRenderData, SphereGeometry, SphereMaterial, SpherePrimitive, Spheres,
 };
 use visula_derive::Instance;
-use wgpu::util::DeviceExt;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct CylinderData {
     start: [f32; 3],
@@ -20,7 +19,6 @@ struct CylinderData {
     end: [f32; 3],
     end_radius: f32,
     color: [f32; 3],
-    _padding: f32,
 }
 
 struct NeuronConfig {
@@ -208,7 +206,6 @@ fn collect_dendrite_cylinders(
             end: dend.points[i + 1].into(),
             end_radius: dend.radii[i + 1],
             color,
-            _padding: 0.0,
         });
 
         if i > 0 {
@@ -216,7 +213,6 @@ fn collect_dendrite_cylinders(
                 position: dend.points[i].into(),
                 radius: dend.radii[i],
                 color,
-                padding: 0.0,
             });
         }
     }
@@ -227,7 +223,6 @@ fn collect_dendrite_cylinders(
             position: (*tip).into(),
             radius: tip_r,
             color,
-            padding: 0.0,
         });
     }
 
@@ -352,7 +347,6 @@ fn generate_axon_cylinders(
             end: p1.into(),
             end_radius: radius,
             color,
-            _padding: 0.0,
         });
     }
 
@@ -467,7 +461,6 @@ fn generate_all(settings: &GenerationSettings) -> GeneratedBufferData {
                 position: soma_pos.into(),
                 radius: neuron.scale,
                 color,
-                padding: 0.0,
             }
         })
         .collect();
@@ -593,25 +586,14 @@ impl ToonNeurons {
                 &app.rendering_descriptor(),
                 &MeshGeometry {
                     position: (*pos).into(),
-                    rotation: Quat::IDENTITY.into(),
-                    scale: Vec3::ONE.into(),
+                    ..Default::default()
                 },
                 &MeshMaterial {
                     color: Expression::InputColor.toon_lit(),
                 },
             )
             .unwrap();
-            mesh.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Synapse vertex buffer"),
-                contents: bytemuck::cast_slice(&vertices),
-                usage: wgpu::BufferUsages::VERTEX,
-            });
-            mesh.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Synapse index buffer"),
-                contents: bytemuck::cast_slice(&indices),
-                usage: wgpu::BufferUsages::INDEX,
-            });
-            mesh.vertex_count = indices.len();
+            mesh.set_mesh_data(device, &vertices, &indices);
             synapse_meshes.push(mesh);
         }
 
@@ -622,26 +604,14 @@ impl ToonNeurons {
             &app.rendering_descriptor(),
             &MeshGeometry {
                 position: Vec3::new(0.0, -0.3, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
+                ..Default::default()
             },
             &MeshMaterial {
                 color: Expression::InputColor.toon_lit(),
             },
         )
         .unwrap();
-
-        dish_floor.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Dish floor vertex buffer"),
-            contents: bytemuck::cast_slice(&floor_verts),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        dish_floor.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Dish floor index buffer"),
-            contents: bytemuck::cast_slice(&floor_indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        dish_floor.vertex_count = floor_indices.len();
+        dish_floor.set_mesh_data(device, &floor_verts, &floor_indices);
 
         let rim_color = hex_to_rgba(0x5a7a50);
         let (rim_verts, rim_indices) = generate_torus(14.0, 0.4, 64, 16, rim_color);
@@ -650,25 +620,14 @@ impl ToonNeurons {
             &app.rendering_descriptor(),
             &MeshGeometry {
                 position: Vec3::new(0.0, -0.1, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
+                ..Default::default()
             },
             &MeshMaterial {
                 color: Expression::InputColor.toon_lit(),
             },
         )
         .unwrap();
-        dish_rim.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Dish rim vertex buffer"),
-            contents: bytemuck::cast_slice(&rim_verts),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        dish_rim.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Dish rim index buffer"),
-            contents: bytemuck::cast_slice(&rim_indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        dish_rim.vertex_count = rim_indices.len();
+        dish_rim.set_mesh_data(device, &rim_verts, &rim_indices);
 
         app.post_processor.config.bloom = Some(visula::post_process::config::BloomConfig {
             threshold: 0.8,
@@ -712,8 +671,6 @@ impl ToonNeurons {
 }
 
 impl visula::Simulation for ToonNeurons {
-    type Error = ();
-
     fn update(&mut self, application: &mut visula::Application) {
         self.rendering_controls.update(application);
         if self.generation_settings.needs_regenerate {

--- a/visula/examples/viewer.rs
+++ b/visula/examples/viewer.rs
@@ -5,7 +5,6 @@ use visula::{MeshMaterial, Renderable};
 
 use bytemuck::{Pod, Zeroable};
 use clap::Parser;
-use glam::{Quat, Vec3};
 use oxifive::ReadSeek;
 use winit::event::{Event, KeyEvent, WindowEvent};
 
@@ -79,11 +78,8 @@ impl Simulation {
     }
 }
 
-#[derive(Debug)]
-struct Error {}
-
 impl Simulation {
-    fn new(application: &mut visula::Application) -> Result<Simulation, Error> {
+    fn new(application: &mut visula::Application) -> Simulation {
         #[cfg(not(target_arch = "wasm32"))]
         let args = Cli::parse();
         let sphere_buffer = InstanceBuffer::<SpherePrimitive>::new(&application.device);
@@ -110,11 +106,7 @@ impl Simulation {
         .unwrap();
         let mesh = MeshPipeline::new(
             &application.rendering_descriptor(),
-            &MeshGeometry {
-                position: Vec3::new(0.0, 0.0, 0.0).into(),
-                rotation: Quat::IDENTITY.into(),
-                scale: Vec3::ONE.into(),
-            },
+            &MeshGeometry::default(),
             &MeshMaterial {
                 color: Expression::from(Vec4::splat(1.0)).lit(),
             },
@@ -134,26 +126,23 @@ impl Simulation {
                 let input = File::open(filename).unwrap();
                 simulation.handle_zdf(application, input);
             }
-            Ok(simulation)
+            simulation
         }
         #[cfg(target_arch = "wasm32")]
         {
-            let simulation = Simulation {
+            Simulation {
                 render_mode: RenderMode::Points,
                 sphere_buffer,
                 spheres: points,
                 mesh,
                 settings: settings_data,
                 settings_buffer,
-            };
-            Ok(simulation)
+            }
         }
     }
 }
 
 impl visula::Simulation for Simulation {
-    type Error = Error;
-
     fn update(&mut self, application: &mut visula::Application) {
         self.settings_buffer
             .update(&application.queue, &self.settings);
@@ -251,5 +240,5 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
-    visula::run(|app| Simulation::new(app).expect("Initializing simulation failed"));
+    visula::run(Simulation::new);
 }

--- a/visula/src/io/zdf.rs
+++ b/visula/src/io/zdf.rs
@@ -139,7 +139,6 @@ pub fn read_zdf<R: ReadSeek>(
                 position: position.into(),
                 radius,
                 color: color.into(),
-                padding: 0.0,
             })
         })
         .collect();

--- a/visula/src/lib.rs
+++ b/visula/src/lib.rs
@@ -34,8 +34,8 @@ pub use cgmath;
 pub use egui_wgpu;
 pub use visula_core;
 pub use visula_core::{
-    glam, naga, uuid, wgpu, Expression, InstanceBuffer, InstanceDeviceExt, TextureInput,
-    UniformBuffer,
+    glam, naga, uuid, vec2, vec3, vec4, wgpu, Expression, InstanceBuffer, InstanceDeviceExt,
+    TextureInput, UniformBuffer,
 };
 
 pub mod application;

--- a/visula/src/painter.rs
+++ b/visula/src/painter.rs
@@ -7,22 +7,20 @@ use glam::Vec3;
 use visula_core::Expression;
 use visula_derive::Instance;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable, Default)]
 struct LineData {
     start: Vec3,
     end: Vec3,
     color: Vec3,
-    _padding: [f32; 3],
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Instance, Pod, Zeroable, Default)]
 struct SphereData {
     position: Vec3,
     color: Vec3,
     radius: f32,
-    _padding: f32,
 }
 
 #[derive(Clone, Copy, Debug, Instance, Default)]
@@ -101,7 +99,6 @@ impl Painter {
             start: line.start,
             end: line.end,
             color: line.color,
-            _padding: Default::default(),
         }));
     }
     pub fn spheres(&mut self, spheres: &[Sphere]) {
@@ -110,7 +107,6 @@ impl Painter {
                 position: sphere.position,
                 color: sphere.color,
                 radius: sphere.radius,
-                _padding: Default::default(),
             }));
     }
 

--- a/visula/src/pipelines/cylinders.rs
+++ b/visula/src/pipelines/cylinders.rs
@@ -3,6 +3,7 @@ use crate::rendering_descriptor::RenderingDescriptor;
 use crate::simulation::{RenderData, ShadowRenderData};
 use crate::Renderable;
 use bytemuck::{Pod, Zeroable};
+use glam::Vec3;
 use std::mem::size_of;
 use visula_core::Expression;
 use visula_derive::Delegate;
@@ -56,6 +57,26 @@ pub struct CylinderGeometry {
 #[derive(Delegate)]
 pub struct CylinderMaterial {
     pub color: Expression,
+}
+
+impl Default for CylinderGeometry {
+    fn default() -> Self {
+        CylinderGeometry {
+            start: Vec3::ZERO.into(),
+            end: Vec3::X.into(),
+            start_radius: 0.1.into(),
+            end_radius: 0.1.into(),
+            color: Vec3::ONE.into(),
+        }
+    }
+}
+
+impl Default for CylinderMaterial {
+    fn default() -> Self {
+        CylinderMaterial {
+            color: Expression::InputColor.lit(),
+        }
+    }
 }
 
 impl Cylinders {

--- a/visula/src/pipelines/lines.rs
+++ b/visula/src/pipelines/lines.rs
@@ -64,7 +64,7 @@ impl Default for LineGeometry {
 impl Default for LineMaterial {
     fn default() -> Self {
         LineMaterial {
-            color: Vec3::new(1.0, 1.0, 1.0).into(),
+            color: Expression::InputColor.lit(),
         }
     }
 }

--- a/visula/src/pipelines/mesh.rs
+++ b/visula/src/pipelines/mesh.rs
@@ -1,6 +1,7 @@
 use std::cell::Ref;
 use std::mem::size_of;
 
+use glam::{Quat, Vec3};
 use naga::back::wgsl::WriterFlags;
 use naga::valid::ValidationFlags;
 use wgpu::util::DeviceExt;
@@ -30,6 +31,24 @@ pub struct MeshGeometry {
 #[derive(Delegate)]
 pub struct MeshMaterial {
     pub color: Expression,
+}
+
+impl Default for MeshGeometry {
+    fn default() -> Self {
+        MeshGeometry {
+            rotation: Quat::IDENTITY.into(),
+            position: Vec3::ZERO.into(),
+            scale: Vec3::ONE.into(),
+        }
+    }
+}
+
+impl Default for MeshMaterial {
+    fn default() -> Self {
+        MeshMaterial {
+            color: Expression::InputColor.lit(),
+        }
+    }
 }
 
 impl MeshPipeline {
@@ -201,6 +220,25 @@ impl MeshPipeline {
             vertex_binding_builder,
             fragment_binding_builder,
         })
+    }
+
+    pub fn set_mesh_data(
+        &mut self,
+        device: &wgpu::Device,
+        vertices: &[MeshVertexAttributes],
+        indices: &[u32],
+    ) {
+        self.vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Mesh vertex buffer"),
+            contents: bytemuck::cast_slice(vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        self.index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Mesh index buffer"),
+            contents: bytemuck::cast_slice(indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+        self.vertex_count = indices.len();
     }
 
     pub fn render(

--- a/visula/src/pipelines/spheres.rs
+++ b/visula/src/pipelines/spheres.rs
@@ -3,6 +3,7 @@ use crate::rendering_descriptor::RenderingDescriptor;
 use crate::simulation::{RenderData, ShadowRenderData};
 use crate::Renderable;
 use bytemuck::{Pod, Zeroable};
+use glam::Vec3;
 use std::mem::size_of;
 use visula_core::Expression;
 use visula_derive::Delegate;
@@ -47,6 +48,24 @@ pub struct SphereGeometry {
 #[derive(Delegate)]
 pub struct SphereMaterial {
     pub color: Expression,
+}
+
+impl Default for SphereGeometry {
+    fn default() -> Self {
+        SphereGeometry {
+            position: Vec3::ZERO.into(),
+            radius: 1.0.into(),
+            color: Vec3::ONE.into(),
+        }
+    }
+}
+
+impl Default for SphereMaterial {
+    fn default() -> Self {
+        SphereMaterial {
+            color: Expression::InputColor.lit(),
+        }
+    }
 }
 
 impl Spheres {

--- a/visula/src/pipelines/torus.rs
+++ b/visula/src/pipelines/torus.rs
@@ -3,6 +3,7 @@ use crate::rendering_descriptor::RenderingDescriptor;
 use crate::simulation::{RenderData, ShadowRenderData};
 use crate::Renderable;
 use bytemuck::{Pod, Zeroable};
+use glam::{Quat, Vec3};
 use std::mem::size_of;
 use visula_core::Expression;
 use visula_derive::Delegate;
@@ -56,6 +57,26 @@ pub struct TorusGeometry {
 #[derive(Delegate)]
 pub struct TorusMaterial {
     pub color: Expression,
+}
+
+impl Default for TorusGeometry {
+    fn default() -> Self {
+        TorusGeometry {
+            position: Vec3::ZERO.into(),
+            major_radius: 1.0.into(),
+            minor_radius: 0.25.into(),
+            rotation: Quat::IDENTITY.into(),
+            color: Vec3::ONE.into(),
+        }
+    }
+}
+
+impl Default for TorusMaterial {
+    fn default() -> Self {
+        TorusMaterial {
+            color: Expression::InputColor.lit(),
+        }
+    }
 }
 
 impl Torus {

--- a/visula/src/primitives/sphere_primitive.rs
+++ b/visula/src/primitives/sphere_primitive.rs
@@ -1,11 +1,10 @@
 use bytemuck::{Pod, Zeroable};
 use visula_derive::*;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 pub struct SpherePrimitive {
     pub position: [f32; 3],
     pub radius: f32,
     pub color: [f32; 3],
-    pub padding: f32,
 }

--- a/visula/src/simulation.rs
+++ b/visula/src/simulation.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use egui::Context;
 use winit::event::Event;
 
@@ -26,7 +24,6 @@ pub struct ShadowRenderData<'a> {
 }
 
 pub trait Simulation {
-    type Error: Debug;
     fn handle_event(&mut self, _application: &mut Application, _event: &Event<CustomEvent>) {}
     fn update(&mut self, _application: &mut Application) {}
     fn render(&mut self, _data: &mut RenderData) {}
@@ -42,11 +39,7 @@ pub trait Simulation {
     }
 }
 
-impl<E> Simulation for Box<dyn Simulation<Error = E>>
-where
-    E: Debug,
-{
-    type Error = E;
+impl Simulation for Box<dyn Simulation> {
     fn handle_event(&mut self, application: &mut Application, event: &Event<CustomEvent>) {
         self.as_mut().handle_event(application, event)
     }

--- a/visula_core/src/value.rs
+++ b/visula_core/src/value.rs
@@ -817,44 +817,46 @@ impl std::fmt::Debug for Expression {
     }
 }
 
-impl Div<f32> for Expression {
+impl<T> Div<T> for Expression
+where
+    T: Into<Expression>,
+{
     type Output = Expression;
 
-    fn div(self, other: f32) -> Expression {
-        let other_scalar: Expression = other.into();
+    fn div(self, other: T) -> Expression {
+        let other_expression: Expression = other.into();
         Expression::BinaryOperator {
             left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other_scalar),
+            right: ExpressionInner::new(other_expression),
             operator: naga::BinaryOperator::Divide,
         }
     }
 }
 
-impl Div<f32> for &Expression {
+impl<T> Div<T> for &Expression
+where
+    Expression: From<T>,
+{
     type Output = Expression;
 
-    fn div(self, other: f32) -> Expression {
-        self.clone() / other
+    fn div(self, other: T) -> Expression {
+        self.clone() / Expression::from(other)
     }
 }
 
-impl Div<Expression> for Expression {
+impl Div<Expression> for f32 {
     type Output = Expression;
 
     fn div(self, other: Expression) -> Expression {
-        Expression::BinaryOperator {
-            left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other),
-            operator: naga::BinaryOperator::Divide,
-        }
+        Expression::from(self) / other
     }
 }
 
-impl Div<Expression> for &Expression {
+impl Div<&Expression> for f32 {
     type Output = Expression;
 
-    fn div(self, other: Expression) -> Expression {
-        self.clone() / other
+    fn div(self, other: &Expression) -> Expression {
+        Expression::from(self) / other
     }
 }
 
@@ -965,31 +967,94 @@ impl Add<&Expression> for glam::Vec4 {
     }
 }
 
-impl Sub<Expression> for Expression {
+impl<T> Sub<T> for Expression
+where
+    T: Into<Expression>,
+{
     type Output = Expression;
 
-    fn sub(self, other: Expression) -> Expression {
+    fn sub(self, other: T) -> Expression {
+        let other_expression: Expression = other.into();
         Expression::BinaryOperator {
             left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other),
+            right: ExpressionInner::new(other_expression),
             operator: naga::BinaryOperator::Subtract,
         }
     }
 }
 
-impl Sub<&Expression> for Expression {
+impl<T> Sub<T> for &Expression
+where
+    Expression: From<T>,
+{
     type Output = Expression;
 
-    fn sub(self, other: &Expression) -> Expression {
-        self - other.clone()
+    fn sub(self, other: T) -> Expression {
+        self.clone() - Expression::from(other)
     }
 }
 
-impl Sub<&Expression> for &Expression {
+impl Sub<Expression> for f32 {
+    type Output = Expression;
+
+    fn sub(self, other: Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<&Expression> for f32 {
     type Output = Expression;
 
     fn sub(self, other: &Expression) -> Expression {
-        self.clone() - other.clone()
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<Expression> for glam::Vec2 {
+    type Output = Expression;
+
+    fn sub(self, other: Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<&Expression> for glam::Vec2 {
+    type Output = Expression;
+
+    fn sub(self, other: &Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<Expression> for glam::Vec3 {
+    type Output = Expression;
+
+    fn sub(self, other: Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<&Expression> for glam::Vec3 {
+    type Output = Expression;
+
+    fn sub(self, other: &Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<Expression> for glam::Vec4 {
+    type Output = Expression;
+
+    fn sub(self, other: Expression) -> Expression {
+        Expression::from(self) - other
+    }
+}
+
+impl Sub<&Expression> for glam::Vec4 {
+    type Output = Expression;
+
+    fn sub(self, other: &Expression) -> Expression {
+        Expression::from(self) - other
     }
 }
 
@@ -1004,71 +1069,65 @@ impl Neg for Expression {
     }
 }
 
-impl Mul<Expression> for Expression {
+impl Neg for &Expression {
     type Output = Expression;
 
-    fn mul(self, other: Expression) -> Expression {
+    fn neg(self) -> Expression {
+        -self.clone()
+    }
+}
+
+impl<T> Mul<T> for Expression
+where
+    T: Into<Expression>,
+{
+    type Output = Expression;
+
+    fn mul(self, other: T) -> Expression {
+        let other_expression: Expression = other.into();
         Expression::BinaryOperator {
             left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other),
+            right: ExpressionInner::new(other_expression),
             operator: naga::BinaryOperator::Multiply,
         }
     }
 }
 
-impl Mul<&Expression> for Expression {
+impl<T> Mul<T> for &Expression
+where
+    Expression: From<T>,
+{
     type Output = Expression;
 
-    fn mul(self, other: &Expression) -> Expression {
-        self * other.clone()
+    fn mul(self, other: T) -> Expression {
+        self.clone() * Expression::from(other)
     }
 }
 
-impl Mul<&Expression> for &Expression {
+impl<T> Rem<T> for Expression
+where
+    T: Into<Expression>,
+{
     type Output = Expression;
 
-    fn mul(self, other: &Expression) -> Expression {
-        self.clone() * other.clone()
-    }
-}
-
-impl Rem<Expression> for Expression {
-    type Output = Expression;
-
-    fn rem(self, other: Expression) -> Expression {
+    fn rem(self, other: T) -> Expression {
+        let other_expression: Expression = other.into();
         Expression::BinaryOperator {
             left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other),
+            right: ExpressionInner::new(other_expression),
             operator: naga::BinaryOperator::Modulo,
         }
     }
 }
 
-impl Rem<&Expression> for Expression {
+impl<T> Rem<T> for &Expression
+where
+    Expression: From<T>,
+{
     type Output = Expression;
 
-    fn rem(self, other: &Expression) -> Expression {
-        self % other.clone()
-    }
-}
-
-impl Rem<&Expression> for &Expression {
-    type Output = Expression;
-
-    fn rem(self, other: &Expression) -> Expression {
-        self.clone() % other.clone()
-    }
-}
-
-impl Mul<f32> for Expression {
-    type Output = Expression;
-
-    fn mul(self, other: f32) -> Expression {
-        Expression::BinaryOperator {
-            left: ExpressionInner::new(self),
-            right: ExpressionInner::new(other.into()),
-            operator: naga::BinaryOperator::Multiply,
-        }
+    fn rem(self, other: T) -> Expression {
+        self.clone() % Expression::from(other)
     }
 }
 
@@ -1152,5 +1211,56 @@ impl From<glam::Quat> for Expression {
             z: value.z.into(),
             w: value.w.into(),
         }
+    }
+}
+
+impl From<[f32; 2]> for Expression {
+    fn from(value: [f32; 2]) -> Expression {
+        vec2(value[0], value[1])
+    }
+}
+
+impl From<[f32; 3]> for Expression {
+    fn from(value: [f32; 3]) -> Expression {
+        vec3(value[0], value[1], value[2])
+    }
+}
+
+impl From<[f32; 4]> for Expression {
+    fn from(value: [f32; 4]) -> Expression {
+        vec4(value[0], value[1], value[2], value[3])
+    }
+}
+
+pub fn vec2(x: impl Into<ExpressionInner>, y: impl Into<ExpressionInner>) -> Expression {
+    Expression::Vector2 {
+        x: x.into(),
+        y: y.into(),
+    }
+}
+
+pub fn vec3(
+    x: impl Into<ExpressionInner>,
+    y: impl Into<ExpressionInner>,
+    z: impl Into<ExpressionInner>,
+) -> Expression {
+    Expression::Vector3 {
+        x: x.into(),
+        y: y.into(),
+        z: z.into(),
+    }
+}
+
+pub fn vec4(
+    x: impl Into<ExpressionInner>,
+    y: impl Into<ExpressionInner>,
+    z: impl Into<ExpressionInner>,
+    w: impl Into<ExpressionInner>,
+) -> Expression {
+    Expression::Vector4 {
+        x: x.into(),
+        y: y.into(),
+        z: z.into(),
+        w: w.into(),
     }
 }

--- a/visula_pyo3/src/lib_impl.rs
+++ b/visula_pyo3/src/lib_impl.rs
@@ -26,25 +26,22 @@ use visula_core::{UniformBufferInner, UniformField};
 use visula_derive::Instance;
 use wgpu::BufferUsages;
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct SphereData {
     position: [f32; 3],
-    _padding: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct PointData {
     position: [f32; 3],
-    _padding: f32,
 }
 
-#[repr(C, align(16))]
+#[repr(C)]
 #[derive(Clone, Copy, Instance, Pod, Zeroable)]
 struct FloatData {
     position: f32,
-    _padding: [f32; 3],
 }
 
 #[pyclass(name = "SphereDelegate", unsendable)]
@@ -363,10 +360,7 @@ impl PyInstanceBuffer {
             .to_vec(py)?
             .iter()
             .copied()
-            .map(|x| FloatData {
-                position: x as f32,
-                _padding: Default::default(),
-            })
+            .map(|x| FloatData { position: x as f32 })
             .collect();
         buffer.update(&application.device, &application.queue, &point_data);
         Ok(PyInstanceBuffer { inner: buffer })
@@ -387,10 +381,7 @@ impl PyInstanceBuffer {
             .to_vec(py)?
             .iter()
             .copied()
-            .map(|x| FloatData {
-                position: x as f32,
-                _padding: Default::default(),
-            })
+            .map(|x| FloatData { position: x as f32 })
             .collect();
         self.inner
             .update(&application.device, &application.queue, &point_data);
@@ -407,11 +398,7 @@ impl PyInstanceBuffer {
 #[pyfunction]
 fn vec3(x: &PyExpression, y: &PyExpression, z: &PyExpression) -> PyExpression {
     PyExpression {
-        inner: Expression::Vector3 {
-            x: x.inner.clone().into(),
-            y: y.inner.clone().into(),
-            z: z.inner.clone().into(),
-        },
+        inner: visula_core::vec3(&x.inner, &y.inner, &z.inner),
     }
 }
 
@@ -455,7 +442,6 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: Py<PyAny>) -> PyResul
             .axis_iter(Axis(major_axis))
             .map(|v| PointData {
                 position: [v[0] as f32, v[1] as f32, v[2] as f32],
-                _padding: Default::default(),
             })
             .collect();
 
@@ -472,10 +458,7 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: Py<PyAny>) -> PyResul
             .to_vec(py)?
             .iter()
             .copied()
-            .map(|x| FloatData {
-                position: x as f32,
-                _padding: Default::default(),
-            })
+            .map(|x| FloatData { position: x as f32 })
             .collect();
 
         buffer.update(&application.device, &application.queue, &point_data);
@@ -491,10 +474,7 @@ fn convert(py: Python, pyapplication: &PyApplication, obj: Py<PyAny>) -> PyResul
             .to_vec(py)?
             .iter()
             .copied()
-            .map(|x| FloatData {
-                position: x,
-                _padding: Default::default(),
-            })
+            .map(|x| FloatData { position: x })
             .collect();
 
         buffer.update(&application.device, &application.queue, &point_data);

--- a/visula_pyo3/src/lib_impl/application.rs
+++ b/visula_pyo3/src/lib_impl/application.rs
@@ -45,12 +45,7 @@ struct PySimulation<'a> {
     controls: &'a mut Vec<Py<PySlider>>,
 }
 
-#[derive(Debug)]
-pub struct PySimulationError;
-
 impl Simulation for PySimulation<'_> {
-    type Error = PySimulationError;
-
     fn render(&mut self, data: &mut RenderData) {
         for renderable in self.renderables {
             renderable.render(data);


### PR DESCRIPTION
- Complete the Expression operator matrix: Sub/Mul/Div/Rem are now generic over Into<Expression> like Add, with scalar- and vector-on-the-left impls, so expressions like `expr - 1.0`, `1.0 / expr` and `Vec3::ONE - expr` compile
- Add vec2/vec3/vec4 helpers and From<[f32; N]> conversions, replacing verbose Expression::Vector3 literals
- Remove the unused Simulation::Error associated type, dropping the dummy error structs from every example
- Add Default impls for the remaining geometry and material structs; materials default to Expression::InputColor.lit()
- Add MeshPipeline::set_mesh_data to replace the repeated create_buffer_init dance
- Drop unnecessary #[repr(C, align(16))] and padding fields from instance structs; vertex attribute offsets accumulate sequentially, so plain #[repr(C)] with 4-byte-aligned fields matches exactly
- Add a minimal spheres example mirroring the Python README sample and update the README accordingly

Breaking changes: Simulation::Error is gone, SpherePrimitive lost its padding field, concrete operator impls were replaced by generics, and LineMaterial::default() now uses lit input color instead of flat white.