### PR TITLE
Fix left mouse input in the Python bindings

### DIFF
--- a/visula/src/camera/controller.rs
+++ b/visula/src/camera/controller.rs
@@ -233,9 +233,13 @@ impl CameraController {
                 self.window_size = *size;
             }
             WindowEvent::ModifiersChanged(state) => {
-                self.control_pressed = state
-                    .state()
-                    .contains(winit::keyboard::ModifiersState::CONTROL);
+                let modifiers = state.state();
+                self.control_pressed = modifiers.contains(winit::keyboard::ModifiersState::CONTROL);
+                let shift_pressed = modifiers.contains(winit::keyboard::ModifiersState::SHIFT);
+                if self.shift_pressed && !shift_pressed {
+                    self.first_intersection = None;
+                }
+                self.shift_pressed = shift_pressed;
             }
             WindowEvent::MouseWheel { delta, .. } if self.zoom_enabled => {
                 let diff = match delta {
@@ -301,6 +305,7 @@ impl CameraController {
                         self.left_pressed = false;
                         response.captured_event = self.state == State::Moving;
                         self.state = State::Released;
+                        self.first_intersection = None;
                     }
                 },
                 MouseButton::Right => match state {

--- a/visula_pyo3/src/lib_impl/application.rs
+++ b/visula_pyo3/src/lib_impl/application.rs
@@ -177,6 +177,18 @@ impl ApplicationHandler<CustomEvent> for PyApplication {
         }
     }
 
+    fn device_event(
+        &mut self,
+        event_loop: &winit::event_loop::ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        let Some(ref mut application) = self.application else {
+            return;
+        };
+        application.device_event(event_loop, device_id, &event);
+    }
+
     fn user_event(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop, event: CustomEvent) {
         match event {
             CustomEvent::Application(application) => self.application = Some(*application),


### PR DESCRIPTION
- PyApplication implemented only window_event, so winit's no-op default swallowed every DeviceEvent. Left-drag rotation is driven by DeviceEvent::MouseMotion, so it did nothing in Python while right-drag panning kept working through WindowEvent::CursorMoved. Forward device events to Application like the Rust handler does
- window_event returned early when no update callback was set, dropping all window events including camera input and redraws; the guard now covers only the callback invocation
- shift_pressed was declared and read but never assigned, leaving both the shift+left-drag pan branch and the shift guard in device_event dead. Track SHIFT alongside CONTROL in ModifiersChanged
- Clear first_intersection on left release and on shift release. It was only cleared on right release, so with shift panning enabled a second shift+left drag would have jumped by a stale offset